### PR TITLE
Search in tree view

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,6 +636,19 @@
                     <div class="spinner-border spinner-border-sm text-secondary" role="status"></div>
                 </div>
 
+                <div id="tree-search" class="tree-search" style="display: none;">
+                    <div class="tree-search__input-wrapper">
+                        <div class="tree-search__input-group">
+                            <i class="bi bi-search tree-search__icon"></i>
+                            <input type="text" id="tree-search-input" class="form-control form-control-sm"
+                                   placeholder="Search in tree (min. 3 characters, Enter to jump)" autocomplete="off">
+                            <button type="button" id="tree-search-clear" class="tree-search__clear" title="Clear search"><i class="bi bi-x-lg"></i></button>
+                        </div>
+                        <span id="tree-search-count" class="tree-search__count"></span>
+                        <button type="button" id="tree-search-prev" class="btn btn-sm btn-outline-secondary" title="Previous match" disabled><i class="bi bi-chevron-up"></i></button>
+                        <button type="button" id="tree-search-next" class="btn btn-sm btn-outline-secondary" title="Next match" disabled><i class="bi bi-chevron-down"></i></button>
+                    </div>
+                </div>
                 <div id="tree-container" class="tree-view"></div>
                 <div id="turtle-container" style="display: none;"></div>
                 <div id="backlinks-container" style="display: none;">

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1092,13 +1092,12 @@ main {
 
 .data-sticky-header {
   position: sticky;
-  top: 0;
+  top: var(--sticky-nav-height, 141px);
   background: #fff;
-  z-index: 10;
-  padding: 0 0 8px 0;
+  z-index: 11;
+  padding: 8px 0;
   margin: 0 !important;
   border-bottom: none;
-  position: relative;
 }
 .data-sticky-header::before {
   content: '';
@@ -1145,6 +1144,75 @@ main {
 }
 [aria-expanded="true"] .explorer-procedure-chevron {
   transform: rotate(90deg);
+}
+
+/* ── Tree search ── */
+
+.tree-search {
+  margin-bottom: 0.5rem;
+  position: sticky;
+  top: calc(var(--sticky-nav-height, 141px) + var(--data-header-height, 44px));
+  z-index: 9;
+  background-color: #fff;
+  padding: 8px 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.tree-search__input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.tree-search__input-group {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.tree-search__icon {
+  position: absolute;
+  left: 10px;
+  color: #999;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.tree-search__input-group input {
+  padding-left: 30px;
+  padding-right: 28px;
+  width: 100%;
+}
+
+.tree-search__clear {
+  position: absolute;
+  right: 4px;
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+  z-index: 1;
+}
+
+.tree-search__clear:hover {
+  color: #333;
+}
+
+.tree-search__count {
+  font-size: 0.75rem;
+  color: #666;
+  white-space: nowrap;
+  min-width: 4em;
+  text-align: center;
+}
+
+.tree-search-highlight-current {
+  background-color: #fff3cd !important;
+  border-left: 4px solid #ff9632 !important;
+  scroll-margin-top: calc(var(--sticky-nav-height, 141px) + 80px);
 }
 
 /* ── Tree view ── */

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1212,6 +1212,7 @@ main {
 .tree-search-highlight-current {
   background-color: #fff3cd !important;
   border-left: 4px solid #ff9632 !important;
+  padding-left: 4px !important;
   scroll-margin-top: calc(var(--sticky-nav-height, 141px) + 80px);
 }
 

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -47,6 +47,7 @@ import { getLabel, getQuery } from './facets.js';
 import { getEndpoint } from './services/sparqlService.js';
 import { showToast } from './utils/toast.js';
 import { TreeRenderer } from './TreeRenderer.js';
+import { TreeSearch } from './TreeSearch.js';
 
 export class DataView {
   // `pickRandom` is an optional callback wired from script.js to
@@ -88,6 +89,7 @@ export class DataView {
     this.downloadMenu = document.getElementById('data-download-menu');
 
     this.treeRenderer = new TreeRenderer(this.treeContainer);
+    this.treeSearch = new TreeSearch(this.treeRenderer);
 
     this._bindEvents();
     this._listen();
@@ -437,6 +439,7 @@ export class DataView {
     this._renderTurtle('');
     const backlinksContent = document.getElementById('backlinks-content');
     if (backlinksContent) backlinksContent.innerHTML = '';
+    this.treeSearch.hide();
   }
 
   _onLoadingChanged() {
@@ -444,6 +447,7 @@ export class DataView {
   }
 
   _renderView(results) {
+    this.treeSearch.clear();
     if (this.viewMode === 'tree') {
       this.treeRenderer.render(results.quads);
     } else if (this.viewMode === 'turtle') {
@@ -453,7 +457,9 @@ export class DataView {
   }
 
   _showCurrentView() {
-    this.treeContainer.style.display = this.viewMode === 'tree' ? '' : 'none';
+    const isTree = this.viewMode === 'tree';
+    this.treeContainer.style.display = isTree ? '' : 'none';
+    if (isTree) this.treeSearch.show(); else this.treeSearch.hide();
     this.turtleContainer.style.display = this.viewMode === 'turtle' ? '' : 'none';
     this.backlinksContainer.style.display = this.viewMode === 'backlinks' ? '' : 'none';
 

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -31,10 +31,14 @@ export class TreeRenderer {
   constructor(container) {
     this.container = container;
     this.subjectIndex = null; // Map<subject, Map<predicate, object[]>>
+    this._toggles = new Map();  // subjectValue → { toggle, expand, collapse, card }
+    this._searchIndex = [];     // flat array of { label, subjectValue, kind }
   }
 
   render(quads) {
     this.container.innerHTML = '';
+    this._toggles.clear();
+    this._searchIndex = [];
 
     if (!quads || quads.length === 0) {
       this.container.innerHTML = '<div class="text-muted fst-italic py-3 text-center">No triples to display</div>';
@@ -42,6 +46,7 @@ export class TreeRenderer {
     }
 
     this.subjectIndex = this._buildIndex(quads);
+    this._buildSearchIndex();
     const roots = this._findRootSubjects(quads);
 
     // `ancestors` is per-branch, not global: the same subject can appear
@@ -49,6 +54,116 @@ export class TreeRenderer {
     for (const subj of roots) {
       const node = this._renderSubjectTree(subj, new Set(), null);
       this.container.appendChild(node);
+    }
+  }
+
+  // Search the tree for a query string. Returns an array of
+  // { subjectValue, kind, label } entries matching the query.
+  search(query) {
+    if (!query || !query.trim()) return [];
+    const words = query.toLowerCase().split(/\s+/).filter(w => w.length > 0);
+    if (words.length === 0) return [];
+    return this._searchIndex.filter(e => {
+      const text = e.label.toLowerCase();
+      return words.every(w => text.includes(w));
+    });
+  }
+
+  // Expand the path from root to a subject, forcing lazy card
+  // creation at each level. Then optionally find a specific row.
+  // Returns the matching DOM element (row or card).
+  // `path` is the ancestor chain captured during the DFS index walk.
+  reveal(subjectValue, predValue, objValue, path) {
+    // Use the path from the search index entry (cycle-safe by
+    // construction) or fall back to just the subject itself.
+    const chain = path || [subjectValue];
+
+    // Expand each level from root down, forcing lazy card creation
+    for (const subj of chain) {
+      const entry = this._toggles.get(subj);
+      if (entry) entry.expand();
+    }
+
+    const entry = this._toggles.get(subjectValue);
+    if (!entry) return null;
+
+    // If a specific predicate+object is given, find the matching element.
+    if (predValue && objValue) {
+      // First try leaf rows (predicate → literal/non-nestable object)
+      const rows = entry.card.querySelectorAll(':scope > .tree-card-body > .tree-node');
+      for (const row of rows) {
+        if (row.dataset.predicate === predValue && row.dataset.objectValue === objValue) {
+          return row;
+        }
+      }
+      // Then try nested card headers (predicate → nestable subject)
+      const nestedCards = entry.card.querySelectorAll(':scope > .tree-card-body > .tree-card');
+      for (const nested of nestedCards) {
+        if (nested.dataset.subject === objValue) {
+          return nested.querySelector('.tree-card-header') || nested;
+        }
+      }
+    }
+
+    // Fallback: highlight just the header, not the entire card
+    return entry.card.querySelector('.tree-card-header') || entry.card;
+  }
+
+  get searchIndex() {
+    return this._searchIndex;
+  }
+
+  _buildSearchIndex() {
+    const localName = (uri) => {
+      const hash = uri.lastIndexOf('#');
+      const slash = uri.lastIndexOf('/');
+      return uri.substring(Math.max(hash, slash) + 1);
+    };
+
+    // Walk the tree depth-first in display order. Each search entry
+    // carries the ancestor path so reveal() can expand from root
+    // without relying on a parent map (which breaks on cycles).
+    const roots = this._findRootSubjects([...this._flatQuads()]);
+    const visited = new Set();
+    const walk = (subj, ancestorPath) => {
+      if (visited.has(subj)) return;
+      visited.add(subj);
+      const predicates = this.subjectIndex.get(subj);
+      if (!predicates) return;
+
+      const path = [...ancestorPath, subj];
+
+      for (const [pred, objects] of predicates) {
+        const predLabel = localName(pred);
+        for (const obj of objects) {
+          const objLabel = obj.termType === 'Literal' ? obj.value : localName(obj.value);
+          this._searchIndex.push({
+            label: `${predLabel} → ${objLabel}`,
+            predLabel, objLabel,
+            subjectValue: subj,
+            predValue: pred,
+            objValue: obj.value,
+            path,
+            kind: 'row',
+          });
+          // Recurse into nestable objects (same logic as _partitionObjects)
+          const isSubject = this.subjectIndex.has(obj.value);
+          const isNode = obj.termType === 'NamedNode' || obj.termType === 'BlankNode';
+          if (isSubject && isNode) walk(obj.value, path);
+        }
+      }
+    };
+    for (const root of roots) walk(root, []);
+  }
+
+  // Yield all quads from the subject index (for _findRootSubjects).
+  *_flatQuads() {
+    for (const [subj, predicates] of this.subjectIndex) {
+      for (const [pred, objects] of predicates) {
+        for (const obj of objects) {
+          yield { subject: { value: subj }, predicate: { value: pred }, object: obj };
+        }
+      }
     }
   }
 
@@ -98,6 +213,7 @@ export class TreeRenderer {
 
     const card = document.createElement('div');
     card.className = 'tree-card';
+    card.dataset.subject = subjectValue;
     card.appendChild(this._buildCardHeader(subjectValue, predicates, incomingPredicate));
 
     // Root cards render their body eagerly so the tree is
@@ -115,19 +231,28 @@ export class TreeRenderer {
     toggle.textContent = startExpanded ? '▼' : '▶';
     toggle.setAttribute('aria-expanded', String(startExpanded));
 
-    const toggleBody = () => {
+    const expand = () => {
       if (!body) {
         body = buildBody();
         card.appendChild(body);
-        toggle.textContent = '▼';
-        toggle.setAttribute('aria-expanded', 'true');
-        return;
       }
-      const collapsed = body.style.display === 'none';
-      body.style.display = collapsed ? '' : 'none';
-      toggle.textContent = collapsed ? '▼' : '▶';
-      toggle.setAttribute('aria-expanded', String(collapsed));
+      body.style.display = '';
+      toggle.textContent = '▼';
+      toggle.setAttribute('aria-expanded', 'true');
     };
+
+    const collapse = () => {
+      if (body) body.style.display = 'none';
+      toggle.textContent = '▶';
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    const toggleBody = () => {
+      if (!body || body.style.display === 'none') expand();
+      else collapse();
+    };
+
+    this._toggles.set(subjectValue, { toggle, expand, collapse, card });
 
     toggle.addEventListener('click', (e) => { e.stopPropagation(); toggleBody(); });
     // Keyboard activation for screen-reader and keyboard-only users.
@@ -226,6 +351,8 @@ export class TreeRenderer {
   _renderPredicateObject(predValue, object) {
     const row = document.createElement('div');
     row.className = 'tree-node';
+    row.dataset.predicate = predValue;
+    row.dataset.objectValue = object.value;
 
     const pred = renderTerm({ termType: 'NamedNode', value: predValue });
     pred.classList.add('predicate');

--- a/src/js/TreeSearch.js
+++ b/src/js/TreeSearch.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// TreeSearch — search-in-tree controller.
+//
+// Wires a search input to the TreeRenderer's in-memory search index.
+// On each keystroke, filters the index, highlights matching results,
+// and provides prev/next navigation to cycle through them.
+
+export class TreeSearch {
+  constructor(treeRenderer) {
+    this.treeRenderer = treeRenderer;
+    this.input = document.getElementById('tree-search-input');
+    this.countEl = document.getElementById('tree-search-count');
+    this.prevBtn = document.getElementById('tree-search-prev');
+    this.nextBtn = document.getElementById('tree-search-next');
+    this.clearBtn = document.getElementById('tree-search-clear');
+    this.searchContainer = document.getElementById('tree-search');
+
+    this.matches = [];
+    this.currentIndex = -1;
+    this._highlights = [];
+
+    this._initListeners();
+  }
+
+  show() {
+    if (this.searchContainer) this.searchContainer.style.display = '';
+  }
+
+  hide() {
+    if (this.searchContainer) this.searchContainer.style.display = 'none';
+    this.clear();
+  }
+
+  clear() {
+    if (this.input) this.input.value = '';
+    this.matches = [];
+    this.currentIndex = -1;
+    this._clearHighlights();
+    this._updateUI();
+  }
+
+  _initListeners() {
+    if (!this.input) return;
+
+    let debounceTimer = null;
+    this.input.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => this._onSearch(), 150);
+    });
+
+    this.input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        // First Enter reveals the current match; subsequent ones step forward
+        if (this._highlights.length === 0 && this.matches.length > 0) {
+          this._revealCurrent();
+        } else if (e.shiftKey) {
+          this._prev();
+        } else {
+          this._next();
+        }
+      }
+      if (e.key === 'Escape') {
+        this.clear();
+        this.input.blur();
+      }
+    });
+
+    this.prevBtn?.addEventListener('click', () => this._prev());
+    this.nextBtn?.addEventListener('click', () => this._next());
+    this.clearBtn?.addEventListener('click', () => this.clear());
+  }
+
+  _onSearch() {
+    const query = this.input.value.trim();
+    this._clearHighlights();
+
+    if (query.length < 3) {
+      this.matches = [];
+      this.currentIndex = -1;
+      this._updateUI();
+      return;
+    }
+
+    // Search the tree renderer's index — each match is a specific row.
+    // Cap at 100 results to avoid UI freezes on broad queries.
+    const all = this.treeRenderer.search(query);
+    this.matches = all.length > 100 ? all.slice(0, 100) : all;
+
+    this.currentIndex = this.matches.length > 0 ? 0 : -1;
+    this._updateUI();
+    // Don't auto-reveal on input — wait for Enter or Next/Prev click.
+  }
+
+  _next() {
+    if (this.matches.length === 0) return;
+    this.currentIndex = (this.currentIndex + 1) % this.matches.length;
+    this._updateUI();
+    this._revealCurrent();
+  }
+
+  _prev() {
+    if (this.matches.length === 0) return;
+    this.currentIndex = (this.currentIndex - 1 + this.matches.length) % this.matches.length;
+    this._updateUI();
+    this._revealCurrent();
+  }
+
+  _revealCurrent() {
+    this._clearHighlights();
+    const match = this.matches[this.currentIndex];
+    if (!match) return;
+
+    const el = this.treeRenderer.reveal(match.subjectValue, match.predValue, match.objValue, match.path);
+    if (!el) return;
+
+    el.classList.add('tree-search-highlight-current');
+    this._highlights.push(el);
+
+    // Defer scroll to after DOM layout from lazy expansion
+    requestAnimationFrame(() => {
+      el.scrollIntoView({ block: 'center' });
+    });
+  }
+
+  _clearHighlights() {
+    for (const el of this._highlights) {
+      el.classList.remove('tree-search-highlight', 'tree-search-highlight-current');
+    }
+    this._highlights = [];
+  }
+
+  _updateUI() {
+    const n = this.matches.length;
+    const hasMatches = n > 0;
+
+    if (this.countEl) {
+      this.countEl.textContent = this.input.value.trim()
+        ? (hasMatches ? `${this.currentIndex + 1} of ${n}` : 'No matches')
+        : '';
+    }
+
+    if (this.prevBtn) this.prevBtn.disabled = !hasMatches;
+    if (this.nextBtn) this.nextBtn.disabled = !hasMatches;
+  }
+}

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -32,6 +32,10 @@ import { setController } from './TermRenderer.js';
 const SPARQL_ENDPOINT = 'https://publications.europa.eu/webapi/rdf/sparql';
 const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-rdf-docs/main/docs/antora/modules/samples/queries/';
 
+// Reset scroll on page load (browsers may restore previous scroll position).
+if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+window.scrollTo(0, 0);
+
 document.addEventListener('DOMContentLoaded', function () {
   // Fail loudly if the Bootstrap JS bundle did not load. Tabs,
   // dropdowns, tooltips, collapse panels, carousel and toasts all
@@ -121,11 +125,25 @@ document.addEventListener('DOMContentLoaded', function () {
     const globan = document.querySelector('.eu-globan');
     const scrollableHeader = document.querySelector('.site-header--scrollable');
     const stickyNav = document.querySelector('.sticky-nav');
-    const total = (globan?.offsetHeight || 0) + (scrollableHeader?.offsetHeight || 0) + (stickyNav?.offsetHeight || 0);
+    const stickyNavHeight = stickyNav?.offsetHeight || 0;
+    const total = (globan?.offsetHeight || 0) + (scrollableHeader?.offsetHeight || 0) + stickyNavHeight;
     document.documentElement.style.setProperty('--header-total-height', total + 'px');
+    document.documentElement.style.setProperty('--sticky-nav-height', stickyNavHeight + 'px');
+    const dataHeader = document.querySelector('.data-sticky-header');
+    if (dataHeader) {
+      document.documentElement.style.setProperty('--data-header-height', dataHeader.offsetHeight + 'px');
+    }
   };
   measureHeader();
   window.addEventListener('resize', measureHeader);
+
+  // Re-measure when the data header changes size (breadcrumb wrap, view-mode toggle).
+  const dataHeader = document.querySelector('.data-sticky-header');
+  if (dataHeader && typeof ResizeObserver !== 'undefined') {
+    new ResizeObserver(() => {
+      document.documentElement.style.setProperty('--data-header-height', dataHeader.offsetHeight + 'px');
+    }).observe(dataHeader);
+  }
 
   // EU globan "How do you know?" toggle
   const globanBtn = document.querySelector('.eu-globan__button');
@@ -145,10 +163,21 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   // Ensure CM6 editors re-measure when their Bootstrap tabs become visible.
+  // On tab switch, scroll so the non-sticky header (globan + EU logo) is
+  // just out of view, leaving the sticky title row + tabs visible at the top.
+  const scrollableHeaderHeight = () => {
+    const globan = document.querySelector('.eu-globan');
+    const upper = document.querySelector('.site-header--scrollable');
+    return (globan?.offsetHeight || 0) + (upper?.offsetHeight || 0);
+  };
   document.querySelectorAll('[data-bs-toggle="tab"]').forEach(tab => {
     tab.addEventListener('shown.bs.tab', () => {
       queryEditor.editor.requestMeasure();
       queryLibrary.querySparqlEditor.requestMeasure();
+      const target = scrollableHeaderHeight();
+      if (window.scrollY > target) {
+        window.scrollTo(0, target);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Adds a search box to the graph tree view, allowing users to find predicates, values, and types without manually expanding nodes.

Closes #61

- Search input above the tree with min 3 characters, multi-word AND matching
- Prev/Next navigation (buttons + Enter/Shift+Enter)
- Highlights the specific row or card header, scrolls to centre of viewport
- Expands ancestor cards automatically to reveal nested matches
- Matches ordered by visual tree position (depth-first)
- Sticky below the breadcrumb bar, hidden on Turtle/Backlinks views
- No network requests — searches the in-memory quad index
- Tab switch resets scroll; page reload starts at top

## Test plan

- [ ] Inspect a notice, search for "amount" — verify matches found in nested cards
- [x] Search for "contact name" (multi-word) — verify it matches `hasContactName`
- [x] Click Next/Prev — verify matches navigate top-to-bottom
- [x] Verify highlight is visible (yellow bg + orange left border)
- [x] Switch to Turtle view — verify search bar hides
- [x] Switch tabs — verify scroll resets appropriately
- [x] `npm test` passes (14/14)