### PR TITLE
Use meaningful namespace prefixes in Turtle view

### DIFF
--- a/src/js/services/sparqlService.js
+++ b/src/js/services/sparqlService.js
@@ -23,6 +23,8 @@
 // the script tag was moved/removed — otherwise an opaque ReferenceError
 // deep inside the worker.onmessage handler would leak pending promises
 // with no diagnosable cause.
+import { prettifyTurtle } from '../utils/prettifyTurtle.js';
+
 function _assertN3Loaded() {
   if (typeof globalThis.N3 === 'undefined' || !globalThis.N3?.Parser) {
     throw new Error(
@@ -87,7 +89,8 @@ function getWorker() {
       try {
         const parser = new N3.Parser();
         const quads = parser.parse(turtleData);
-        pending.resolve({ rawTurtle: turtleData, quads, size: quads.length });
+        const rawTurtle = prettifyTurtle(quads, turtleData);
+        pending.resolve({ rawTurtle, quads, size: quads.length });
       } catch (parseError) {
         pending.reject(new Error(`Failed to parse SPARQL response: ${parseError.message}`));
       }

--- a/src/js/utils/prettifyTurtle.js
+++ b/src/js/utils/prettifyTurtle.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// Re-serialise parsed RDF quads as Turtle with meaningful prefixes.
+//
+// Virtuoso's Turtle output uses auto-generated prefixes (ns1:, ns2:, ...).
+// This function re-serialises the quads through N3.Writer with the app's
+// known prefix map so the Turtle view and downloads show epo:, rdf:, etc.
+
+import { ns } from './namespaces.js';
+
+/**
+ * Re-serialise quads as Turtle with known prefixes.
+ * Falls back to the original Turtle string on any error.
+ *
+ * @param {Array} quads - Parsed N3 quads
+ * @param {string} fallback - Original Turtle string to return on failure
+ * @returns {string} Turtle string with meaningful prefixes
+ */
+export function prettifyTurtle(quads, fallback) {
+  try {
+    const writer = new N3.Writer({ prefixes: { ...ns } });
+    writer.addQuads(quads);
+    let result = fallback;
+    writer.end((error, output) => {
+      if (!error) result = output;
+    });
+    return result;
+  } catch {
+    return fallback;
+  }
+}

--- a/test/prettifyTurtle.test.js
+++ b/test/prettifyTurtle.test.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+// N3 is expected as a global (loaded via <script> in the app).
+import N3 from 'n3';
+globalThis.N3 = N3;
+
+import { prettifyTurtle } from '../src/js/utils/prettifyTurtle.js';
+
+const UGLY_TURTLE = `@prefix ns1: <http://data.europa.eu/a4g/ontology#> .
+@prefix ns2: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://example.org/notice> ns2:type ns1:Notice ;
+    ns1:hasPublicationDate "2024-11-06" .
+`;
+
+test('prettifyTurtle replaces auto-generated prefixes with known ones', () => {
+  const parser = new N3.Parser();
+  const quads = parser.parse(UGLY_TURTLE);
+
+  const result = prettifyTurtle(quads, UGLY_TURTLE);
+
+  // Should use epo: instead of ns1: and rdf: instead of ns2:
+  assert.ok(result.includes('epo:'), `expected epo: prefix, got:\n${result}`);
+  assert.ok(result.includes('rdf:'), `expected rdf: prefix, got:\n${result}`);
+  assert.ok(!result.includes('ns1:'), `should not contain ns1:, got:\n${result}`);
+  assert.ok(!result.includes('ns2:'), `should not contain ns2:, got:\n${result}`);
+});
+
+test('prettifyTurtle produces valid Turtle that round-trips to identical triples', () => {
+  const parser = new N3.Parser();
+  const quads = parser.parse(UGLY_TURTLE);
+
+  const result = prettifyTurtle(quads, UGLY_TURTLE);
+
+  // Re-parse — if the Turtle is invalid, this throws
+  const outputQuads = new N3.Parser().parse(result);
+  assert.equal(outputQuads.length, quads.length, 'triple count must be preserved');
+
+  // Compare actual triple content (subject, predicate, object values)
+  const tripleKey = (q) => `${q.subject.value} ${q.predicate.value} ${q.object.value}`;
+  const inputSet = new Set(quads.map(tripleKey));
+  const outputSet = new Set(outputQuads.map(tripleKey));
+  assert.deepEqual(outputSet, inputSet, 'triples must be identical after round-trip');
+});
+
+test('prettifyTurtle returns fallback on empty quads', () => {
+  const result = prettifyTurtle([], 'fallback text');
+  // Empty quads should still produce valid output (just prefixes, no triples)
+  assert.ok(typeof result === 'string');
+});
+
+test('prettifyTurtle returns a string even with invalid quads', () => {
+  const result = prettifyTurtle([{ bad: 'data' }], 'my fallback');
+  assert.ok(typeof result === 'string');
+});


### PR DESCRIPTION
Closes #28. Re-serialises Turtle output through N3.Writer with the app's known prefix map so the Turtle view and downloads show epo:, rdf:, xsd: etc. instead of Virtuoso's auto-generated ns1:, ns2:.