### PR TITLE
Release 2.1.0

### DIFF
--- a/index.html
+++ b/index.html
@@ -636,6 +636,19 @@
                     <div class="spinner-border spinner-border-sm text-secondary" role="status"></div>
                 </div>
 
+                <div id="tree-search" class="tree-search" style="display: none;">
+                    <div class="tree-search__input-wrapper">
+                        <div class="tree-search__input-group">
+                            <i class="bi bi-search tree-search__icon"></i>
+                            <input type="text" id="tree-search-input" class="form-control form-control-sm"
+                                   placeholder="Search in tree (min. 3 characters, Enter to jump)" autocomplete="off">
+                            <button type="button" id="tree-search-clear" class="tree-search__clear" title="Clear search"><i class="bi bi-x-lg"></i></button>
+                        </div>
+                        <span id="tree-search-count" class="tree-search__count"></span>
+                        <button type="button" id="tree-search-prev" class="btn btn-sm btn-outline-secondary" title="Previous match" disabled><i class="bi bi-chevron-up"></i></button>
+                        <button type="button" id="tree-search-next" class="btn btn-sm btn-outline-secondary" title="Next match" disabled><i class="bi bi-chevron-down"></i></button>
+                    </div>
+                </div>
                 <div id="tree-container" class="tree-view"></div>
                 <div id="turtle-container" style="display: none;"></div>
                 <div id="backlinks-container" style="display: none;">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data",
-  "version": "2.1.0-SNAPSHOT",
+  "version": "2.1.0",
   "description": "TED Open Data Service — SPARQL playground and notice browser for the European public procurement dataset",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data",
-  "version": "2.0.0",
+  "version": "2.1.0-SNAPSHOT",
   "description": "TED Open Data Service — SPARQL playground and notice browser for the European public procurement dataset",
   "type": "module",
   "scripts": {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1147,6 +1147,87 @@ main {
   transform: rotate(90deg);
 }
 
+/* ── Tree info popover ── */
+
+.tree-info-btn {
+  background: none;
+  border: none;
+  color: #d63384;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 0.85rem;
+  vertical-align: middle;
+  margin-left: 12px;
+}
+
+.tree-info-popover {
+  font-family: inherit;
+  font-size: 0.8rem;
+}
+
+.tree-info-intro {
+  font-size: 0.75rem;
+  color: #666;
+  margin: 0 0 6px 0;
+}
+
+.tree-info-row {
+  margin-bottom: 4px;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.tree-info-label {
+  font-weight: 600;
+  margin-right: 6px;
+  color: #515560;
+}
+
+.tree-info-value {
+  font-size: 0.75rem;
+  word-break: break-all;
+  flex: 1;
+}
+
+.tree-info-copy-inline {
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 0.7rem;
+  flex-shrink: 0;
+}
+
+.tree-info-copy-inline:hover {
+  color: #004494;
+}
+
+.tree-info-popover-container {
+  max-width: 700px;
+  border: 1px solid rgba(0, 0, 0, 0.35);
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.15);
+}
+
+.tree-info-popover-container .popover-body {
+  width: min(650px, calc(100vw - 2rem));
+}
+
+.tree-info-popover-container .popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background-color: #f5f5f5;
+}
+
+.tree-info-close {
+  font-size: 0.6rem;
+  padding: 0.25rem;
+}
+
 /* ── Tree view ── */
 
 .tree-view {

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1092,13 +1092,12 @@ main {
 
 .data-sticky-header {
   position: sticky;
-  top: 0;
+  top: var(--sticky-nav-height, 141px);
   background: #fff;
-  z-index: 10;
-  padding: 0 0 8px 0;
+  z-index: 11;
+  padding: 8px 0;
   margin: 0 !important;
   border-bottom: none;
-  position: relative;
 }
 .data-sticky-header::before {
   content: '';
@@ -1145,6 +1144,75 @@ main {
 }
 [aria-expanded="true"] .explorer-procedure-chevron {
   transform: rotate(90deg);
+}
+
+/* ── Tree search ── */
+
+.tree-search {
+  margin-bottom: 0.5rem;
+  position: sticky;
+  top: calc(var(--sticky-nav-height, 141px) + var(--data-header-height, 44px));
+  z-index: 9;
+  background-color: #fff;
+  padding: 8px 0;
+  border-bottom: 1px solid #dee2e6;
+}
+
+.tree-search__input-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.tree-search__input-group {
+  position: relative;
+  flex: 1;
+  display: flex;
+  align-items: center;
+}
+
+.tree-search__icon {
+  position: absolute;
+  left: 10px;
+  color: #999;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.tree-search__input-group input {
+  padding-left: 30px;
+  padding-right: 28px;
+  width: 100%;
+}
+
+.tree-search__clear {
+  position: absolute;
+  right: 4px;
+  background: none;
+  border: none;
+  color: #999;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-size: 0.75rem;
+  z-index: 1;
+}
+
+.tree-search__clear:hover {
+  color: #333;
+}
+
+.tree-search__count {
+  font-size: 0.75rem;
+  color: #666;
+  white-space: nowrap;
+  min-width: 4em;
+  text-align: center;
+}
+
+.tree-search-highlight-current {
+  background-color: #fff3cd !important;
+  border-left: 4px solid #ff9632 !important;
+  scroll-margin-top: calc(var(--sticky-nav-height, 141px) + 80px);
 }
 
 /* ── Tree view ── */

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -1212,6 +1212,7 @@ main {
 .tree-search-highlight-current {
   background-color: #fff3cd !important;
   border-left: 4px solid #ff9632 !important;
+  padding-left: 4px !important;
   scroll-margin-top: calc(var(--sticky-nav-height, 141px) + 80px);
 }
 

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -456,6 +456,14 @@ export class DataView {
       this._renderTurtle(results.rawTurtle);
     }
     this._showCurrentView();
+
+    // Scroll up so the new content is visible after navigation.
+    const globan = document.querySelector('.eu-globan');
+    const upper = document.querySelector('.site-header--scrollable');
+    const target = (globan?.offsetHeight || 0) + (upper?.offsetHeight || 0);
+    if (window.scrollY > target) {
+      window.scrollTo(0, target);
+    }
   }
 
   _showCurrentView() {

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -47,6 +47,7 @@ import { getLabel, getQuery } from './facets.js';
 import { getEndpoint } from './services/sparqlService.js';
 import { showToast } from './utils/toast.js';
 import { TreeRenderer } from './TreeRenderer.js';
+import { TreeSearch } from './TreeSearch.js';
 
 export class DataView {
   // `pickRandom` is an optional callback wired from script.js to
@@ -88,6 +89,7 @@ export class DataView {
     this.downloadMenu = document.getElementById('data-download-menu');
 
     this.treeRenderer = new TreeRenderer(this.treeContainer);
+    this.treeSearch = new TreeSearch(this.treeRenderer);
 
     this._bindEvents();
     this._listen();
@@ -437,6 +439,7 @@ export class DataView {
     this._renderTurtle('');
     const backlinksContent = document.getElementById('backlinks-content');
     if (backlinksContent) backlinksContent.innerHTML = '';
+    this.treeSearch.hide();
   }
 
   _onLoadingChanged() {
@@ -444,6 +447,7 @@ export class DataView {
   }
 
   _renderView(results) {
+    this.treeSearch.clear();
     if (this.viewMode === 'tree') {
       this.treeRenderer.render(results.quads);
     } else if (this.viewMode === 'turtle') {
@@ -453,7 +457,9 @@ export class DataView {
   }
 
   _showCurrentView() {
-    this.treeContainer.style.display = this.viewMode === 'tree' ? '' : 'none';
+    const isTree = this.viewMode === 'tree';
+    this.treeContainer.style.display = isTree ? '' : 'none';
+    if (isTree) this.treeSearch.show(); else this.treeSearch.hide();
     this.turtleContainer.style.display = this.viewMode === 'turtle' ? '' : 'none';
     this.backlinksContainer.style.display = this.viewMode === 'backlinks' ? '' : 'none';
 

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -445,7 +445,9 @@ export class DataView {
 
   _renderView(results) {
     if (this.viewMode === 'tree') {
-      this.treeRenderer.render(results.quads);
+      const facet = this.controller.currentFacet;
+      const subjectUri = facet?.type === 'named-node' ? facet.term?.value : null;
+      this.treeRenderer.render(results.quads, { subjectUri });
     } else if (this.viewMode === 'turtle') {
       this._renderTurtle(results.rawTurtle);
     }

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -22,8 +22,9 @@
 // outer tree renders. This keeps the initial render fast even for notices
 // with tens of thousands of triples.
 
-import { ns } from './utils/namespaces.js';
+import { ns, resolvePrefix, shrink } from './utils/namespaces.js';
 import { renderSubjectBadge, renderTerm } from './TermRenderer.js';
+import { copyToClipboard } from './utils/clipboardCopy.js';
 
 const RDF_TYPE = ns.rdf + 'type';
 
@@ -31,13 +32,31 @@ export class TreeRenderer {
   constructor(container) {
     this.container = container;
     this.subjectIndex = null; // Map<subject, Map<predicate, object[]>>
+    this._activePopover = null;
   }
 
-  render(quads) {
+  render(quads, { subjectUri } = {}) {
+    this._dismissPopover();
     this.container.innerHTML = '';
 
     if (!quads || quads.length === 0) {
-      this.container.innerHTML = '<div class="text-muted fst-italic py-3 text-center">No triples to display</div>';
+      if (subjectUri) {
+        // Show an empty card with the header + info button
+        const card = document.createElement('div');
+        card.className = 'tree-card';
+        const predicates = new Map();
+        const header = this._buildCardHeader(subjectUri, predicates, null);
+        const toggle = header.querySelector('.tree-toggle');
+        if (toggle) toggle.remove();
+        card.appendChild(header);
+        const body = document.createElement('div');
+        body.className = 'tree-card-body';
+        body.innerHTML = '<div class="text-muted fst-italic py-3 text-center">No triples to display</div>';
+        card.appendChild(body);
+        this.container.appendChild(card);
+      } else {
+        this.container.innerHTML = '<div class="text-muted fst-italic py-3 text-center">No triples to display</div>';
+      }
       return;
     }
 
@@ -180,14 +199,137 @@ export class TreeRenderer {
       header.appendChild(document.createTextNode(' → '));
     }
 
-    const hasTypes = (predicates.get(RDF_TYPE) || []).length > 0;
-    if (hasTypes) {
-      header.appendChild(renderSubjectBadge(subjectValue));
-    } else {
-      header.appendChild(renderTerm({ termType: 'NamedNode', value: subjectValue }));
+    header.appendChild(renderSubjectBadge(subjectValue));
+
+    // Add info icon for root-level cards (no incoming predicate)
+    if (!incomingPredicate) {
+      header.appendChild(this._buildInfoButton(subjectValue, predicates));
     }
 
     return header;
+  }
+
+  _dismissPopover() {
+    if (this._activePopoverCleanup) {
+      this._activePopoverCleanup();
+      this._activePopoverCleanup = null;
+    }
+    if (this._activePopover) {
+      this._activePopover.hide();
+      this._activePopover.dispose();
+      this._activePopover = null;
+    }
+  }
+
+  _buildInfoButton(subjectValue, predicates) {
+    const btn = document.createElement('button');
+    btn.className = 'tree-info-btn';
+    btn.setAttribute('aria-label', 'SPARQL reference card');
+    btn.setAttribute('title', 'Click here for referencing this element in your SPARQL query');
+    btn.innerHTML = '<i class="bi bi-code-square"></i>';
+    const tooltip = new bootstrap.Tooltip(btn, { placement: 'top' });
+
+    const esc = (s) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+
+    const resolved = resolvePrefix(subjectValue);
+    const types = (predicates.get(RDF_TYPE) || []).map(t => shrink(t.value));
+    const title = `<span>SPARQL reference card</span><button class="btn-close tree-info-close" aria-label="Close"></button>`;
+
+    const copyIcon = (value, label) =>
+      `<button class="tree-info-copy-inline" data-copy="${esc(value)}" title="${label}"><i class="bi bi-clipboard"></i></button>`;
+
+    const rows = [
+      `<p class="tree-info-intro">Use the following in your SPARQL query</p>`,
+    ];
+
+    if (resolved) {
+      // Ontology/vocabulary term — PREFIX, Name
+      const prefixDecl = `PREFIX ${resolved.prefix}: <${ns[resolved.prefix]}>`;
+      const prefixedName = `${resolved.prefix}:${resolved.localName}`;
+      rows.push(`<div class="tree-info-row"><span class="tree-info-label">Prefix</span>${copyIcon(prefixDecl, 'Copy prefix declaration')}<code class="tree-info-value">${esc(prefixDecl)}</code></div>`);
+      rows.push(`<div class="tree-info-row"><span class="tree-info-label">Name</span>${copyIcon(prefixedName, 'Copy name')}<code class="tree-info-value">${esc(prefixedName)}</code></div>`);
+    } else {
+      // Data resource — PREFIX (from type), Name (type), IRI
+      if (types.length) {
+        const typeResolved = resolvePrefix((predicates.get(RDF_TYPE) || [])[0]?.value);
+        if (typeResolved) {
+          const typePrefixDecl = `PREFIX ${typeResolved.prefix}: <${ns[typeResolved.prefix]}>`;
+          rows.push(`<div class="tree-info-row"><span class="tree-info-label">Prefix</span>${copyIcon(typePrefixDecl, 'Copy prefix declaration')}<code class="tree-info-value">${esc(typePrefixDecl)}</code></div>`);
+        }
+        rows.push(`<div class="tree-info-row"><span class="tree-info-label">Name</span>${copyIcon(types[0], 'Copy name')}<code class="tree-info-value">${esc(types.join(', '))}</code></div>`);
+      }
+      const iri = `<${subjectValue}>`;
+      rows.push(`<div class="tree-info-row"><span class="tree-info-label">IRI</span>${copyIcon(iri, 'Copy IRI')}<code class="tree-info-value">${esc(iri)}</code></div>`);
+    }
+
+    const lines = [`<div class="tree-info-popover">`, ...rows, `</div>`].join('\n');
+
+    const popover = new bootstrap.Popover(btn, {
+      title,
+      content: lines,
+      html: true,
+      sanitize: false,
+      placement: 'bottom',
+      trigger: 'manual',
+      container: 'body',
+      customClass: 'tree-info-popover-container',
+    });
+
+    btn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      tooltip.hide();
+      tooltip.disable();
+      if (this._activePopover === popover) {
+        popover.hide();
+        this._activePopover = null;
+        tooltip.enable();
+      } else {
+        this._dismissPopover();
+        popover.show();
+        this._activePopover = popover;
+      }
+    });
+
+    btn.addEventListener('hidden.bs.popover', () => {
+      tooltip.enable();
+    });
+
+    btn.addEventListener('shown.bs.popover', () => {
+      const tip = popover.tip;
+      if (!tip) return;
+      const onOutsideClick = (e) => {
+        if (!tip.contains(e.target) && !btn.contains(e.target)) {
+          popover.hide();
+          this._activePopover = null;
+          document.removeEventListener('click', onOutsideClick, true);
+        }
+      };
+      document.addEventListener('click', onOutsideClick, true);
+      const cleanup = () => {
+        document.removeEventListener('click', onOutsideClick, true);
+      };
+      this._activePopoverCleanup = cleanup;
+      btn.addEventListener('hidden.bs.popover', () => {
+        cleanup();
+        if (this._activePopoverCleanup === cleanup) this._activePopoverCleanup = null;
+      }, { once: true });
+      const closeBtn = tip.querySelector('.tree-info-close');
+      if (closeBtn) {
+        closeBtn.addEventListener('click', () => {
+          popover.hide();
+          this._activePopover = null;
+        });
+      }
+      tip.querySelectorAll('.tree-info-copy-inline').forEach(cb => {
+        cb.addEventListener('click', async () => {
+          const ok = await copyToClipboard(cb.dataset.copy);
+          cb.innerHTML = ok ? '<i class="bi bi-check"></i>' : '<i class="bi bi-x"></i>';
+          setTimeout(() => { cb.innerHTML = '<i class="bi bi-clipboard"></i>'; }, 1500);
+        });
+      });
+    });
+
+    return btn;
   }
 
   _buildCardBody(predicates, branchAncestors) {

--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -31,10 +31,14 @@ export class TreeRenderer {
   constructor(container) {
     this.container = container;
     this.subjectIndex = null; // Map<subject, Map<predicate, object[]>>
+    this._toggles = new Map();  // subjectValue → { toggle, expand, collapse, card }
+    this._searchIndex = [];     // flat array of { label, subjectValue, kind }
   }
 
   render(quads) {
     this.container.innerHTML = '';
+    this._toggles.clear();
+    this._searchIndex = [];
 
     if (!quads || quads.length === 0) {
       this.container.innerHTML = '<div class="text-muted fst-italic py-3 text-center">No triples to display</div>';
@@ -42,6 +46,7 @@ export class TreeRenderer {
     }
 
     this.subjectIndex = this._buildIndex(quads);
+    this._buildSearchIndex();
     const roots = this._findRootSubjects(quads);
 
     // `ancestors` is per-branch, not global: the same subject can appear
@@ -49,6 +54,116 @@ export class TreeRenderer {
     for (const subj of roots) {
       const node = this._renderSubjectTree(subj, new Set(), null);
       this.container.appendChild(node);
+    }
+  }
+
+  // Search the tree for a query string. Returns an array of
+  // { subjectValue, kind, label } entries matching the query.
+  search(query) {
+    if (!query || !query.trim()) return [];
+    const words = query.toLowerCase().split(/\s+/).filter(w => w.length > 0);
+    if (words.length === 0) return [];
+    return this._searchIndex.filter(e => {
+      const text = e.label.toLowerCase();
+      return words.every(w => text.includes(w));
+    });
+  }
+
+  // Expand the path from root to a subject, forcing lazy card
+  // creation at each level. Then optionally find a specific row.
+  // Returns the matching DOM element (row or card).
+  // `path` is the ancestor chain captured during the DFS index walk.
+  reveal(subjectValue, predValue, objValue, path) {
+    // Use the path from the search index entry (cycle-safe by
+    // construction) or fall back to just the subject itself.
+    const chain = path || [subjectValue];
+
+    // Expand each level from root down, forcing lazy card creation
+    for (const subj of chain) {
+      const entry = this._toggles.get(subj);
+      if (entry) entry.expand();
+    }
+
+    const entry = this._toggles.get(subjectValue);
+    if (!entry) return null;
+
+    // If a specific predicate+object is given, find the matching element.
+    if (predValue && objValue) {
+      // First try leaf rows (predicate → literal/non-nestable object)
+      const rows = entry.card.querySelectorAll(':scope > .tree-card-body > .tree-node');
+      for (const row of rows) {
+        if (row.dataset.predicate === predValue && row.dataset.objectValue === objValue) {
+          return row;
+        }
+      }
+      // Then try nested card headers (predicate → nestable subject)
+      const nestedCards = entry.card.querySelectorAll(':scope > .tree-card-body > .tree-card');
+      for (const nested of nestedCards) {
+        if (nested.dataset.subject === objValue) {
+          return nested.querySelector('.tree-card-header') || nested;
+        }
+      }
+    }
+
+    // Fallback: highlight just the header, not the entire card
+    return entry.card.querySelector('.tree-card-header') || entry.card;
+  }
+
+  get searchIndex() {
+    return this._searchIndex;
+  }
+
+  _buildSearchIndex() {
+    const localName = (uri) => {
+      const hash = uri.lastIndexOf('#');
+      const slash = uri.lastIndexOf('/');
+      return uri.substring(Math.max(hash, slash) + 1);
+    };
+
+    // Walk the tree depth-first in display order. Each search entry
+    // carries the ancestor path so reveal() can expand from root
+    // without relying on a parent map (which breaks on cycles).
+    const roots = this._findRootSubjects([...this._flatQuads()]);
+    const visited = new Set();
+    const walk = (subj, ancestorPath) => {
+      if (visited.has(subj)) return;
+      visited.add(subj);
+      const predicates = this.subjectIndex.get(subj);
+      if (!predicates) return;
+
+      const path = [...ancestorPath, subj];
+
+      for (const [pred, objects] of predicates) {
+        const predLabel = localName(pred);
+        for (const obj of objects) {
+          const objLabel = obj.termType === 'Literal' ? obj.value : localName(obj.value);
+          this._searchIndex.push({
+            label: `${predLabel} → ${objLabel}`,
+            predLabel, objLabel,
+            subjectValue: subj,
+            predValue: pred,
+            objValue: obj.value,
+            path,
+            kind: 'row',
+          });
+          // Recurse into nestable objects (same logic as _partitionObjects)
+          const isSubject = this.subjectIndex.has(obj.value);
+          const isNode = obj.termType === 'NamedNode' || obj.termType === 'BlankNode';
+          if (isSubject && isNode) walk(obj.value, path);
+        }
+      }
+    };
+    for (const root of roots) walk(root, []);
+  }
+
+  // Yield all quads from the subject index (for _findRootSubjects).
+  *_flatQuads() {
+    for (const [subj, predicates] of this.subjectIndex) {
+      for (const [pred, objects] of predicates) {
+        for (const obj of objects) {
+          yield { subject: { value: subj }, predicate: { value: pred }, object: obj };
+        }
+      }
     }
   }
 
@@ -98,6 +213,7 @@ export class TreeRenderer {
 
     const card = document.createElement('div');
     card.className = 'tree-card';
+    card.dataset.subject = subjectValue;
     card.appendChild(this._buildCardHeader(subjectValue, predicates, incomingPredicate));
 
     // Root cards render their body eagerly so the tree is
@@ -115,19 +231,28 @@ export class TreeRenderer {
     toggle.textContent = startExpanded ? '▼' : '▶';
     toggle.setAttribute('aria-expanded', String(startExpanded));
 
-    const toggleBody = () => {
+    const expand = () => {
       if (!body) {
         body = buildBody();
         card.appendChild(body);
-        toggle.textContent = '▼';
-        toggle.setAttribute('aria-expanded', 'true');
-        return;
       }
-      const collapsed = body.style.display === 'none';
-      body.style.display = collapsed ? '' : 'none';
-      toggle.textContent = collapsed ? '▼' : '▶';
-      toggle.setAttribute('aria-expanded', String(collapsed));
+      body.style.display = '';
+      toggle.textContent = '▼';
+      toggle.setAttribute('aria-expanded', 'true');
     };
+
+    const collapse = () => {
+      if (body) body.style.display = 'none';
+      toggle.textContent = '▶';
+      toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    const toggleBody = () => {
+      if (!body || body.style.display === 'none') expand();
+      else collapse();
+    };
+
+    this._toggles.set(subjectValue, { toggle, expand, collapse, card });
 
     toggle.addEventListener('click', (e) => { e.stopPropagation(); toggleBody(); });
     // Keyboard activation for screen-reader and keyboard-only users.
@@ -226,6 +351,8 @@ export class TreeRenderer {
   _renderPredicateObject(predValue, object) {
     const row = document.createElement('div');
     row.className = 'tree-node';
+    row.dataset.predicate = predValue;
+    row.dataset.objectValue = object.value;
 
     const pred = renderTerm({ termType: 'NamedNode', value: predValue });
     pred.classList.add('predicate');

--- a/src/js/TreeSearch.js
+++ b/src/js/TreeSearch.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// TreeSearch — search-in-tree controller.
+//
+// Wires a search input to the TreeRenderer's in-memory search index.
+// On each keystroke, filters the index, highlights matching results,
+// and provides prev/next navigation to cycle through them.
+
+export class TreeSearch {
+  constructor(treeRenderer) {
+    this.treeRenderer = treeRenderer;
+    this.input = document.getElementById('tree-search-input');
+    this.countEl = document.getElementById('tree-search-count');
+    this.prevBtn = document.getElementById('tree-search-prev');
+    this.nextBtn = document.getElementById('tree-search-next');
+    this.clearBtn = document.getElementById('tree-search-clear');
+    this.searchContainer = document.getElementById('tree-search');
+
+    this.matches = [];
+    this.currentIndex = -1;
+    this._highlights = [];
+
+    this._initListeners();
+  }
+
+  show() {
+    if (this.searchContainer) this.searchContainer.style.display = '';
+  }
+
+  hide() {
+    if (this.searchContainer) this.searchContainer.style.display = 'none';
+    this.clear();
+  }
+
+  clear() {
+    if (this.input) this.input.value = '';
+    this.matches = [];
+    this.currentIndex = -1;
+    this._clearHighlights();
+    this._updateUI();
+  }
+
+  _initListeners() {
+    if (!this.input) return;
+
+    let debounceTimer = null;
+    this.input.addEventListener('input', () => {
+      clearTimeout(debounceTimer);
+      debounceTimer = setTimeout(() => this._onSearch(), 150);
+    });
+
+    this.input.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        // First Enter reveals the current match; subsequent ones step forward
+        if (this._highlights.length === 0 && this.matches.length > 0) {
+          this._revealCurrent();
+        } else if (e.shiftKey) {
+          this._prev();
+        } else {
+          this._next();
+        }
+      }
+      if (e.key === 'Escape') {
+        this.clear();
+        this.input.blur();
+      }
+    });
+
+    this.prevBtn?.addEventListener('click', () => this._prev());
+    this.nextBtn?.addEventListener('click', () => this._next());
+    this.clearBtn?.addEventListener('click', () => this.clear());
+  }
+
+  _onSearch() {
+    const query = this.input.value.trim();
+    this._clearHighlights();
+
+    if (query.length < 3) {
+      this.matches = [];
+      this.currentIndex = -1;
+      this._updateUI();
+      return;
+    }
+
+    // Search the tree renderer's index — each match is a specific row.
+    // Cap at 100 results to avoid UI freezes on broad queries.
+    const all = this.treeRenderer.search(query);
+    this.matches = all.length > 100 ? all.slice(0, 100) : all;
+
+    this.currentIndex = this.matches.length > 0 ? 0 : -1;
+    this._updateUI();
+    // Don't auto-reveal on input — wait for Enter or Next/Prev click.
+  }
+
+  _next() {
+    if (this.matches.length === 0) return;
+    this.currentIndex = (this.currentIndex + 1) % this.matches.length;
+    this._updateUI();
+    this._revealCurrent();
+  }
+
+  _prev() {
+    if (this.matches.length === 0) return;
+    this.currentIndex = (this.currentIndex - 1 + this.matches.length) % this.matches.length;
+    this._updateUI();
+    this._revealCurrent();
+  }
+
+  _revealCurrent() {
+    this._clearHighlights();
+    const match = this.matches[this.currentIndex];
+    if (!match) return;
+
+    const el = this.treeRenderer.reveal(match.subjectValue, match.predValue, match.objValue, match.path);
+    if (!el) return;
+
+    el.classList.add('tree-search-highlight-current');
+    this._highlights.push(el);
+
+    // Defer scroll to after DOM layout from lazy expansion
+    requestAnimationFrame(() => {
+      el.scrollIntoView({ block: 'center' });
+    });
+  }
+
+  _clearHighlights() {
+    for (const el of this._highlights) {
+      el.classList.remove('tree-search-highlight', 'tree-search-highlight-current');
+    }
+    this._highlights = [];
+  }
+
+  _updateUI() {
+    const n = this.matches.length;
+    const hasMatches = n > 0;
+
+    if (this.countEl) {
+      this.countEl.textContent = this.input.value.trim()
+        ? (hasMatches ? `${this.currentIndex + 1} of ${n}` : 'No matches')
+        : '';
+    }
+
+    if (this.prevBtn) this.prevBtn.disabled = !hasMatches;
+    if (this.nextBtn) this.nextBtn.disabled = !hasMatches;
+  }
+}

--- a/src/js/facets.js
+++ b/src/js/facets.js
@@ -115,18 +115,17 @@ WHERE {
 // FORBIDDEN_URI_CHARS check here at the point of interpolation. Any URI
 // that would let `>` or quote characters break out of the IRI literal
 // gets thrown before the query is built.
+const EPO_RESOURCE_BASE = 'http://data.europa.eu/a4g/resource/';
+
 function _describeTermQuery(term, noticeNumber) {
   if (!_isSafeUri(term?.value)) {
     throw new Error(`Unsafe URI for DESCRIBE: ${JSON.stringify(term?.value)}`);
   }
-  // When a root notice context is available, scope the query to the
-  // graph containing that notice. Without this, the bare DESCRIBE
-  // returns triples from every named graph where the URI appears,
-  // merging data from multiple notices in the same procedure.
-  if (noticeNumber && /^\d{8}-\d{4}$/.test(noticeNumber)) {
-    // Graph-scoped CBD: fetch the direct triples of the resource plus
-    // one level of blank-node expansion (mirrors DESCRIBE CBD behaviour
-    // but restricted to the graph containing the given notice).
+  // Graph-scope only data resource URIs (subjects within a notice graph).
+  // Ontology terms, vocabulary URIs, and other non-resource URIs use the
+  // unscoped DESCRIBE so they return their full definition across all graphs.
+  const isDataResource = term.value.startsWith(EPO_RESOURCE_BASE);
+  if (isDataResource && noticeNumber && /^\d{8}-\d{4}$/.test(noticeNumber)) {
     return `PREFIX epo: <http://data.europa.eu/a4g/ontology#>
 
 CONSTRUCT {

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -32,6 +32,10 @@ import { setController } from './TermRenderer.js';
 const SPARQL_ENDPOINT = 'https://publications.europa.eu/webapi/rdf/sparql';
 const REMOTE_QUERIES_URL = 'https://raw.githubusercontent.com/OP-TED/ted-rdf-docs/main/docs/antora/modules/samples/queries/';
 
+// Reset scroll on page load (browsers may restore previous scroll position).
+if ('scrollRestoration' in history) history.scrollRestoration = 'manual';
+window.scrollTo(0, 0);
+
 document.addEventListener('DOMContentLoaded', function () {
   // Fail loudly if the Bootstrap JS bundle did not load. Tabs,
   // dropdowns, tooltips, collapse panels, carousel and toasts all
@@ -121,11 +125,25 @@ document.addEventListener('DOMContentLoaded', function () {
     const globan = document.querySelector('.eu-globan');
     const scrollableHeader = document.querySelector('.site-header--scrollable');
     const stickyNav = document.querySelector('.sticky-nav');
-    const total = (globan?.offsetHeight || 0) + (scrollableHeader?.offsetHeight || 0) + (stickyNav?.offsetHeight || 0);
+    const stickyNavHeight = stickyNav?.offsetHeight || 0;
+    const total = (globan?.offsetHeight || 0) + (scrollableHeader?.offsetHeight || 0) + stickyNavHeight;
     document.documentElement.style.setProperty('--header-total-height', total + 'px');
+    document.documentElement.style.setProperty('--sticky-nav-height', stickyNavHeight + 'px');
+    const dataHeader = document.querySelector('.data-sticky-header');
+    if (dataHeader) {
+      document.documentElement.style.setProperty('--data-header-height', dataHeader.offsetHeight + 'px');
+    }
   };
   measureHeader();
   window.addEventListener('resize', measureHeader);
+
+  // Re-measure when the data header changes size (breadcrumb wrap, view-mode toggle).
+  const dataHeader = document.querySelector('.data-sticky-header');
+  if (dataHeader && typeof ResizeObserver !== 'undefined') {
+    new ResizeObserver(() => {
+      document.documentElement.style.setProperty('--data-header-height', dataHeader.offsetHeight + 'px');
+    }).observe(dataHeader);
+  }
 
   // EU globan "How do you know?" toggle
   const globanBtn = document.querySelector('.eu-globan__button');
@@ -145,10 +163,21 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   // Ensure CM6 editors re-measure when their Bootstrap tabs become visible.
+  // On tab switch, scroll so the non-sticky header (globan + EU logo) is
+  // just out of view, leaving the sticky title row + tabs visible at the top.
+  const scrollableHeaderHeight = () => {
+    const globan = document.querySelector('.eu-globan');
+    const upper = document.querySelector('.site-header--scrollable');
+    return (globan?.offsetHeight || 0) + (upper?.offsetHeight || 0);
+  };
   document.querySelectorAll('[data-bs-toggle="tab"]').forEach(tab => {
     tab.addEventListener('shown.bs.tab', () => {
       queryEditor.editor.requestMeasure();
       queryLibrary.querySparqlEditor.requestMeasure();
+      const target = scrollableHeaderHeight();
+      if (window.scrollY > target) {
+        window.scrollTo(0, target);
+      }
     });
   });
 

--- a/src/js/services/sparqlService.js
+++ b/src/js/services/sparqlService.js
@@ -23,6 +23,8 @@
 // the script tag was moved/removed — otherwise an opaque ReferenceError
 // deep inside the worker.onmessage handler would leak pending promises
 // with no diagnosable cause.
+import { prettifyTurtle } from '../utils/prettifyTurtle.js';
+
 function _assertN3Loaded() {
   if (typeof globalThis.N3 === 'undefined' || !globalThis.N3?.Parser) {
     throw new Error(
@@ -87,7 +89,8 @@ function getWorker() {
       try {
         const parser = new N3.Parser();
         const quads = parser.parse(turtleData);
-        pending.resolve({ rawTurtle: turtleData, quads, size: quads.length });
+        const rawTurtle = prettifyTurtle(quads, turtleData);
+        pending.resolve({ rawTurtle, quads, size: quads.length });
       } catch (parseError) {
         pending.reject(new Error(`Failed to parse SPARQL response: ${parseError.message}`));
       }

--- a/src/js/utils/prettifyTurtle.js
+++ b/src/js/utils/prettifyTurtle.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// Re-serialise parsed RDF quads as Turtle with meaningful prefixes.
+//
+// Virtuoso's Turtle output uses auto-generated prefixes (ns1:, ns2:, ...).
+// This function re-serialises the quads through N3.Writer with the app's
+// known prefix map so the Turtle view and downloads show epo:, rdf:, etc.
+
+import { ns } from './namespaces.js';
+
+/**
+ * Re-serialise quads as Turtle with known prefixes.
+ * Falls back to the original Turtle string on any error.
+ *
+ * @param {Array} quads - Parsed N3 quads
+ * @param {string} fallback - Original Turtle string to return on failure
+ * @returns {string} Turtle string with meaningful prefixes
+ */
+export function prettifyTurtle(quads, fallback) {
+  try {
+    const writer = new N3.Writer({ prefixes: { ...ns } });
+    writer.addQuads(quads);
+    let result = fallback;
+    writer.end((error, output) => {
+      if (!error) result = output;
+    });
+    return result;
+  } catch {
+    return fallback;
+  }
+}

--- a/test/facets.test.js
+++ b/test/facets.test.js
@@ -364,6 +364,37 @@ test('getQuery throws on a named-node facet with an unsafe URI (click-time defen
   );
 });
 
+test('getQuery scopes data resource URIs to the notice graph when noticeNumber is given', () => {
+  const dataResource = {
+    type: 'named-node',
+    term: { value: EPO_NOTICE_URI },
+  };
+  const scoped = getQuery(dataResource, { noticeNumber: PUB_2026 });
+  assert.match(scoped, /CONSTRUCT/, 'data resource should use CONSTRUCT');
+  assert.match(scoped, /GRAPH/, 'data resource should have GRAPH clause');
+  assert.match(scoped, new RegExp(PUB_2026), 'should contain the notice number');
+});
+
+test('getQuery does NOT scope ontology/predicate URIs even with noticeNumber', () => {
+  const ontologyUri = {
+    type: 'named-node',
+    term: { value: 'http://data.europa.eu/a4g/ontology#announcesRole' },
+  };
+  const query = getQuery(ontologyUri, { noticeNumber: PUB_2026 });
+  assert.match(query, /DESCRIBE/, 'ontology URI should use DESCRIBE');
+  assert.ok(!query.includes('GRAPH'), 'ontology URI should NOT have GRAPH clause');
+});
+
+test('getQuery does NOT scope vocabulary URIs even with noticeNumber', () => {
+  const vocabUri = {
+    type: 'named-node',
+    term: { value: 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type' },
+  };
+  const query = getQuery(vocabUri, { noticeNumber: PUB_2026 });
+  assert.match(query, /DESCRIBE/, 'vocabulary URI should use DESCRIBE');
+  assert.ok(!query.includes('GRAPH'), 'vocabulary URI should NOT have GRAPH clause');
+});
+
 // ── facetEquals (tested via addUnique) ─────────────────────────────
 
 test('addUnique appends a new facet and returns its index', () => {

--- a/test/prettifyTurtle.test.js
+++ b/test/prettifyTurtle.test.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or - as soon they will be approved by the European
+ * Commission - subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+import { test, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+// N3 is expected as a global (loaded via <script> in the app).
+import N3 from 'n3';
+globalThis.N3 = N3;
+
+import { prettifyTurtle } from '../src/js/utils/prettifyTurtle.js';
+
+const UGLY_TURTLE = `@prefix ns1: <http://data.europa.eu/a4g/ontology#> .
+@prefix ns2: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+<http://example.org/notice> ns2:type ns1:Notice ;
+    ns1:hasPublicationDate "2024-11-06" .
+`;
+
+test('prettifyTurtle replaces auto-generated prefixes with known ones', () => {
+  const parser = new N3.Parser();
+  const quads = parser.parse(UGLY_TURTLE);
+
+  const result = prettifyTurtle(quads, UGLY_TURTLE);
+
+  // Should use epo: instead of ns1: and rdf: instead of ns2:
+  assert.ok(result.includes('epo:'), `expected epo: prefix, got:\n${result}`);
+  assert.ok(result.includes('rdf:'), `expected rdf: prefix, got:\n${result}`);
+  assert.ok(!result.includes('ns1:'), `should not contain ns1:, got:\n${result}`);
+  assert.ok(!result.includes('ns2:'), `should not contain ns2:, got:\n${result}`);
+});
+
+test('prettifyTurtle produces valid Turtle that round-trips to identical triples', () => {
+  const parser = new N3.Parser();
+  const quads = parser.parse(UGLY_TURTLE);
+
+  const result = prettifyTurtle(quads, UGLY_TURTLE);
+
+  // Re-parse — if the Turtle is invalid, this throws
+  const outputQuads = new N3.Parser().parse(result);
+  assert.equal(outputQuads.length, quads.length, 'triple count must be preserved');
+
+  // Compare actual triple content (subject, predicate, object values)
+  const tripleKey = (q) => `${q.subject.value} ${q.predicate.value} ${q.object.value}`;
+  const inputSet = new Set(quads.map(tripleKey));
+  const outputSet = new Set(outputQuads.map(tripleKey));
+  assert.deepEqual(outputSet, inputSet, 'triples must be identical after round-trip');
+});
+
+test('prettifyTurtle returns fallback on empty quads', () => {
+  const result = prettifyTurtle([], 'fallback text');
+  // Empty quads should still produce valid output (just prefixes, no triples)
+  assert.ok(typeof result === 'string');
+});
+
+test('prettifyTurtle returns a string even with invalid quads', () => {
+  const result = prettifyTurtle([{ bad: 'data' }], 'my fallback');
+  assert.ok(typeof result === 'string');
+});


### PR DESCRIPTION
## Summary

Release 2.1.0 of the TED Open Data Service.

### New features
- **Search in tree view** — find predicates, values, and types across the notice graph (#61)
- **SPARQL reference card** — click the [<>] icon on any resource to get copy-pasteable PREFIX declarations and prefixed names (#62)
- **Meaningful namespace prefixes** — Turtle view and downloads use epo:, rdf:, xsd: instead of ns1:, ns2: (#28)

### Bug fixes
- Predicate/ontology URI navigation restored (graph-scoping only applies to data resource URIs)
- Scroll position resets on tab switch and tree navigation
- Various accessibility and clipboard fallback improvements

## Test plan
- [x] Inspect a notice, use tree search, verify matches and navigation
- [x] Click [<>] on a resource, verify SPARQL reference card
- [x] Switch to Turtle view, verify meaningful prefixes
- [x] Click a predicate link, verify it returns triples (not zero)
- [x] `npm test` passes