### PR TITLE
Release 2.1.1 — restore host-based TED API routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data",
-  "version": "2.1.0",
+  "version": "2.2.0-SNAPSHOT",
   "description": "TED Open Data Service — SPARQL playground and notice browser for the European public procurement dataset",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data",
-  "version": "2.2.0-SNAPSHOT",
+  "version": "2.1.1",
   "description": "TED Open Data Service — SPARQL playground and notice browser for the European public procurement dataset",
   "type": "module",
   "scripts": {

--- a/src/js/services/tedAPI.js
+++ b/src/js/services/tedAPI.js
@@ -20,23 +20,16 @@
 
 import { normalize } from '../facets.js';
 
-// Always use the acceptance TED API. The production API
-// (api.ted.europa.eu) does NOT include CORS headers for our deploy
-// origin (docs.ted.europa.eu), so calling it from a browser-based app
-// fails with a preflight error and the procedure timeline does not
-// load. The acceptance API (api.acceptance.ted.europa.eu) does allow
-// the cross-origin request and is what version 1.0.0 of this app used
-// in production unconditionally.
-//
-// This restores parity with 1.0.0. A request has been filed with the
-// TED API admins to enable CORS for docs.ted.europa.eu on the
-// production API; once that lands, this can be flipped back to a
-// per-host switch (see CORS_REQUEST.md at the repo root for the
-// outgoing request and the conditions for re-enabling the switch).
-const TED_API = 'https://api.acceptance.ted.europa.eu/v3';
+// Production TED API for real deployments, acceptance for anywhere else
+// (localhost, preview builds, staging). The acceptance instance holds the
+// same schema but non-production data — safer for dev and exploration.
+const TED_API_PRODUCTION = 'https://api.ted.europa.eu/v3';
+const TED_API_ACCEPTANCE = 'https://api.acceptance.ted.europa.eu/v3';
 
 function getTedApi() {
-  return TED_API;
+  const host = window.location.hostname;
+  const isProduction = host === 'docs.ted.europa.eu' || host === 'data.ted.europa.eu';
+  return isProduction ? TED_API_PRODUCTION : TED_API_ACCEPTANCE;
 }
 const PROCEDURE_NOTICE_LIMIT = 249;
 const NOTICE_LOOKUP_LIMIT = 10;


### PR DESCRIPTION
## Summary

Patch release restoring host-based TED API routing. Mirrors the same fix just shipped in ted-open-data-explorer 2.0.2, where production CORS on `api.ted.europa.eu` has been verified working for `data.ted.europa.eu` and `docs.ted.europa.eu`.

## What ships in 2.1.1

- `src/js/services/tedAPI.js` — host switch restored: `docs.ted.europa.eu` / `data.ted.europa.eu` → `api.ted.europa.eu/v3`, everything else → `api.acceptance.ted.europa.eu/v3`
- `package.json` — version bumped `2.1.0` → `2.1.1`

## Background

Previously `tedAPI.js` was hardcoded to always use the acceptance API because `api.ted.europa.eu` did not allow CORS from our origins. CORS has since been enabled on the production API for `data.ted.europa.eu` (verified via preflight + real POST — both return 200 with `access-control-allow-origin: https://data.ted.europa.eu`).

## Test plan

- [x] After merge and deploy, open https://data.ted.europa.eu/
- [x] Look up a recent notice, confirm the procedure timeline populates (no CORS preflight error in DevTools console)
- [x] Verify the notices-search POST targets `api.ted.europa.eu` (not acceptance)
- [ ] If timeline fails: revert this PR

## Post-merge cleanup

- Merge `main` back into `develop` to keep them in sync
- `develop` already bumped to `2.2.0-SNAPSHOT` — nothing further needed there