### PR TITLE
Display query execution time in results toolbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -504,6 +504,7 @@
                     </button>
                 </span>
                 <div class="results-toolbar-actions">
+                    <span id="query-execution-time" class="small text-muted me-3" style="display: none;"><i class="bi bi-clock"></i> <span id="query-execution-time-value"></span></span>
                     <button type="button" id="copy-url-button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-rocket-takeoff"></i> Copy endpoint URL</button>
                     <div class="dropdown d-inline-block">
                         <button id="download-as-button" class="btn btn-sm btn-outline-primary dropdown-toggle" type="button"

--- a/index.html
+++ b/index.html
@@ -493,18 +493,18 @@
                  #copy-url-alert (the id is kept for JS back-compat,
                  the class has changed from `alert` to a custom bar). -->
             <div id="copy-url-alert" class="results-toolbar d-none">
-                <span id="alert-message" class="results-toolbar-hint tab-prompt"
-                      title="Here are the results of your query.">
-                    Here are the results of your query.
+                <div id="alert-message" class="results-toolbar-hint"
+                     title="Query results">
+                    <h5 class="mb-0 d-inline">Query results</h5>
                     <button type="button" class="tour-trigger" id="reuse-select-tour-trigger"
                             data-bs-toggle="tooltip" data-bs-placement="top"
                             title="Take a quick tour of this tab"
                             aria-label="Take a quick tour of this tab">
                         <i class="bi bi-play-circle"></i>
                     </button>
-                </span>
+                    <p class="small text-muted mb-0" id="query-execution-time" style="display: none;">Execution time: <span id="query-execution-time-value"></span></p>
+                </div>
                 <div class="results-toolbar-actions">
-                    <span id="query-execution-time" class="small text-muted me-3" style="display: none;"><i class="bi bi-clock"></i> <span id="query-execution-time-value"></span></span>
                     <button type="button" id="copy-url-button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-rocket-takeoff"></i> Copy endpoint URL</button>
                     <div class="dropdown d-inline-block">
                         <button id="download-as-button" class="btn btn-sm btn-outline-primary dropdown-toggle" type="button"

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -28,6 +28,7 @@ import {epoCompletionSource, getEpoData} from './epoCompletion.js';
 import {classifyError} from './utils/errorMessages.js';
 import {buildSparqlBody, readSparqlOptions} from './sparqlRequest.js';
 import {copyToClipboard} from './utils/clipboardCopy.js';
+import {formatElapsedTime} from './utils/formatTime.js';
 
 /**
  * Class representing the Query Editor.
@@ -459,16 +460,7 @@ export class QueryEditor {
         const execTimeContainer = document.getElementById('query-execution-time');
         const execTimeValue = document.getElementById('query-execution-time-value');
         if (execTimeContainer && execTimeValue) {
-          const elapsedNum = parseFloat(elapsed);
-          let formattedTime;
-          if (elapsedNum >= 60) {
-            const minutes = Math.floor(elapsedNum / 60);
-            const seconds = Math.round(elapsedNum % 60);
-            formattedTime = `${minutes}m ${seconds}s`;
-          } else {
-            formattedTime = `${elapsed}s`;
-          }
-          execTimeValue.textContent = formattedTime;
+          execTimeValue.textContent = formatElapsedTime(elapsed);
           execTimeContainer.style.display = 'inline';
         }
 

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -461,7 +461,7 @@ export class QueryEditor {
         const execTimeValue = document.getElementById('query-execution-time-value');
         if (execTimeContainer && execTimeValue) {
           execTimeValue.textContent = formatElapsedTime(elapsed);
-          execTimeContainer.style.display = 'inline';
+          execTimeContainer.style.display = 'block';
         }
 
         submitButtons.forEach(b => b.disabled = false);

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -405,6 +405,10 @@ export class QueryEditor {
       this.resultsErrorMessage.textContent = '';
       this.resultsDiv.innerHTML = '';
 
+      // Hide execution time from previous run
+      const execTimeContainer = document.getElementById('query-execution-time');
+      if (execTimeContainer) execTimeContainer.style.display = 'none';
+
       try {
         const query = this.getQuery();
         // The editor always requests SPARQL Results JSON — QueryResults
@@ -450,6 +454,24 @@ export class QueryEditor {
         progressBar.style.width = '0%';
         progressBar.classList.remove('progress-bar-striped', 'progress-bar-animated');
         queryTimer.textContent = `${elapsed}s`;
+
+        // Display the execution time in the results toolbar
+        const execTimeContainer = document.getElementById('query-execution-time');
+        const execTimeValue = document.getElementById('query-execution-time-value');
+        if (execTimeContainer && execTimeValue) {
+          const elapsedNum = parseFloat(elapsed);
+          let formattedTime;
+          if (elapsedNum >= 60) {
+            const minutes = Math.floor(elapsedNum / 60);
+            const seconds = Math.round(elapsedNum % 60);
+            formattedTime = `${minutes}m ${seconds}s`;
+          } else {
+            formattedTime = `${elapsed}s`;
+          }
+          execTimeValue.textContent = formattedTime;
+          execTimeContainer.style.display = 'inline';
+        }
+
         submitButtons.forEach(b => b.disabled = false);
         const hasLibrarySelection = document.querySelector('#query-accordion .list-group-item.active') !== null;
         document.querySelectorAll('#try-query-button, .query-try-btn, #customise-query-button, .query-customise-btn').forEach(b => b.disabled = !hasLibrarySelection);

--- a/src/js/utils/formatTime.js
+++ b/src/js/utils/formatTime.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+
+/**
+ * Format an elapsed time (in seconds) into a human-readable string.
+ * Under 60 seconds: "3.2s"
+ * 60 seconds or above: "2m 5s"
+ *
+ * @param {string|number} seconds - Elapsed time in seconds (e.g. "3.2" or 125.7)
+ * @returns {string} Formatted time string
+ */
+export function formatElapsedTime(seconds) {
+  const num = parseFloat(seconds);
+  if (num >= 60) {
+    const minutes = Math.floor(num / 60);
+    const secs = Math.round(num % 60);
+    return `${minutes}m ${secs}s`;
+  }
+  return `${seconds}s`;
+}

--- a/src/js/utils/formatTime.js
+++ b/src/js/utils/formatTime.js
@@ -23,8 +23,13 @@
 export function formatElapsedTime(seconds) {
   const num = parseFloat(seconds);
   if (num >= 60) {
-    const minutes = Math.floor(num / 60);
-    const secs = Math.round(num % 60);
+    // Round to whole seconds FIRST, then split into minutes/seconds.
+    // Flooring the minutes while independently rounding the remainder can
+    // round it up to 60 and render an impossible "1m 60s" (e.g. 119.7 →
+    // floor→1m, round(59.7)→60s). Rounding the total avoids the rollover.
+    const total = Math.round(num);
+    const minutes = Math.floor(total / 60);
+    const secs = total % 60;
     return `${minutes}m ${secs}s`;
   }
   return `${seconds}s`;

--- a/test/formatTime.test.js
+++ b/test/formatTime.test.js
@@ -42,3 +42,15 @@ test('handles numeric input as well as string input', () => {
   assert.equal(formatElapsedTime(45.3), '45.3s');
   assert.equal(formatElapsedTime(90), '1m 30s');
 });
+
+test('rolls a rounded-up remainder into the next minute instead of "Xm 60s"', () => {
+  // A remainder that rounds up to 60 must carry into the minutes.
+  assert.equal(formatElapsedTime('119.5'), '2m 0s');
+  assert.equal(formatElapsedTime('119.7'), '2m 0s');
+  assert.equal(formatElapsedTime('3599.6'), '60m 0s');
+});
+
+test('rounds sub-second overflow just above a minute to the whole second', () => {
+  assert.equal(formatElapsedTime('60.4'), '1m 0s');
+  assert.equal(formatElapsedTime('60.6'), '1m 1s');
+});

--- a/test/formatTime.test.js
+++ b/test/formatTime.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// formatElapsedTime tests — ensures the execution time display
+// formats correctly for both short and long-running queries.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatElapsedTime } from '../src/js/utils/formatTime.js';
+
+test('formats under 60 seconds as Xs', () => {
+  assert.equal(formatElapsedTime('3.2'), '3.2s');
+});
+
+test('formats a fractional second value correctly', () => {
+  assert.equal(formatElapsedTime('0.5'), '0.5s');
+});
+
+test('formats exactly 60 seconds as 1m 0s', () => {
+  assert.equal(formatElapsedTime('60.0'), '1m 0s');
+});
+
+test('formats 60+ seconds as Mm Ss', () => {
+  assert.equal(formatElapsedTime('125.7'), '2m 6s');
+});
+
+test('formats a large value correctly', () => {
+  assert.equal(formatElapsedTime('3661.0'), '61m 1s');
+});
+
+test('handles numeric input as well as string input', () => {
+  assert.equal(formatElapsedTime(45.3), '45.3s');
+  assert.equal(formatElapsedTime(90), '1m 30s');
+});


### PR DESCRIPTION
Show elapsed time (seconds or minutes+seconds) in the Reuse tab after a query completes. The time is hidden while a new query runs and updated on completion (success or failure).

Closes #69