### PR TITLE
Keep not-found notices in search history with badge

### DIFF
--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -28,6 +28,10 @@
     --ted-blue-10: #E7EDFA;          /* eu-blue-10, hover backgrounds */
     --ted-blue-5: #F3F6FC;           /* eu-blue-5, subtle backgrounds */
 
+    /* Neutrals (OP Global Style) */
+    --ted-gray-10: #EEEEEE;          /* gray-10, navigation selected-state background */
+    --ted-main-75: #697188;          /* main-75, secondary links / neutral chips */
+
     /* Text */
     --ted-text: #333333;             /* gray-100, headings & body */
     --ted-text-muted: #666666;       /* muted text, badge type, type links */
@@ -799,6 +803,31 @@ main {
 .list-group-item.active.query-library-item:hover {
     background-color: var(--ted-blue-hover) !important; /* eu-blue-110 */
     border-color: var(--ted-blue-hover) !important;
+}
+
+/* History dropdown selected/hover states, per the TED style guide:
+   gray-10 is the "navigation selected state" background, paired with an
+   eu-blue-100 left border as the required companion cue (gray-10 alone
+   isn't a sufficient indicator); eu-blue-10 for hover. A transparent left
+   border on every item reserves the space so text doesn't shift on select. */
+#history-menu .dropdown-item {
+    border-left: 3px solid transparent;
+}
+#history-menu .dropdown-item:hover,
+#history-menu .dropdown-item:focus {
+    background-color: var(--ted-blue-10);
+}
+#history-menu .dropdown-item.active,
+#history-menu .dropdown-item.active:hover,
+#history-menu .dropdown-item.active:focus {
+    background-color: var(--ted-gray-10);
+    color: var(--ted-text);
+    border-left-color: var(--ted-blue);
+}
+/* "Not found" chip — main-75 (secondary/neutral) with white text. */
+.badge.badge-not-found {
+    background-color: var(--ted-main-75);
+    color: #fff;
 }
 
 #query-card {

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -376,11 +376,11 @@ export class DataView {
     // CONSTRUCT on a well-formed publication number is a strong "not
     // found" signal. Show a dedicated state instead of an empty tree
     // labelled "0 triples", which users can't distinguish from a real
-    // empty notice. Also ask the controller to evict the phantom entry
-    // from the History dropdown so typos don't pollute recent searches.
+    // empty notice. Mark the facet as not-found in history so the user
+    // can see which searches didn't return data.
     if (currentFacet?.type === 'notice-number' && results.size === 0) {
       this._showNotFound(currentFacet.value);
-      this.controller.removeFacetByValue?.(currentFacet.value);
+      this.controller.markFacetNotFound?.(currentFacet.value);
       return;
     }
 

--- a/src/js/ExplorerController.js
+++ b/src/js/ExplorerController.js
@@ -223,18 +223,6 @@ export class ExplorerController extends EventTarget {
     this._emit('facets-list-changed');
   }
 
-  // Remove a notice-number facet from the persistent history by its
-  // publication-number value. Used by DataView when a search resolves
-  // to zero triples (i.e. the notice does not exist) so the phantom
-  // entry doesn't pollute the History dropdown. No-op if no match.
-  removeFacetByValue(publicationNumber) {
-    const idx = this.facetsList.findIndex(
-      f => f.type === 'notice-number' && f.value === publicationNumber
-    );
-    if (idx < 0) return;
-    this.removeFacet(idx);
-  }
-
   // Mark a notice-number facet as "not found" in the persistent history.
   // Used by DataView when a search resolves to zero triples so the entry
   // stays in history (allowing re-search) but is visually distinguishable
@@ -386,12 +374,6 @@ export class ExplorerController extends EventTarget {
     if (facet.type !== 'notice-number') return facet;
     const { facets, index } = addUnique(this.facetsList, facet);
     this.facetsList = facets;
-    // Clear the notFound flag when re-searching a publication number.
-    // If the notice has since been published, the fresh query will
-    // produce triples and the flag should not linger from a prior miss.
-    if (facets[index].notFound) {
-      delete facets[index].notFound;
-    }
     return facets[index];
   }
 
@@ -491,6 +473,17 @@ export class ExplorerController extends EventTarget {
       }
       this.results = results;
       this.executedQuery = effectiveQuery;
+      // Clear a stale "not found" flag ONLY now that a notice-number search
+      // has actually returned data. Clearing it at search start (before the
+      // query resolves) would wipe the badge on a failed, cancelled, or
+      // still-empty retry, even though the notice was not found. The token
+      // guard above means only the winning query reaches here; the catch and
+      // cancellation branches never do.
+      if (facet.type === 'notice-number' && results.size > 0 && facet.notFound) {
+        delete facet.notFound;
+        this._saveToSession();
+        this._emit('facets-list-changed');
+      }
       this._emit('results-changed');
     } catch (e) {
       if (token !== this._queryToken) return;

--- a/src/js/ExplorerController.js
+++ b/src/js/ExplorerController.js
@@ -235,6 +235,20 @@ export class ExplorerController extends EventTarget {
     this.removeFacet(idx);
   }
 
+  // Mark a notice-number facet as "not found" in the persistent history.
+  // Used by DataView when a search resolves to zero triples so the entry
+  // stays in history (allowing re-search) but is visually distinguishable
+  // from notices that were found.
+  markFacetNotFound(publicationNumber) {
+    const entry = this.facetsList.find(
+      f => f.type === 'notice-number' && f.value === publicationNumber
+    );
+    if (!entry) return;
+    entry.notFound = true;
+    this._saveToSession();
+    this._emit('facets-list-changed');
+  }
+
   // ── URL sharing ──
 
   // Build a shareable URL for the current facet. Only the identity-defining
@@ -372,6 +386,12 @@ export class ExplorerController extends EventTarget {
     if (facet.type !== 'notice-number') return facet;
     const { facets, index } = addUnique(this.facetsList, facet);
     this.facetsList = facets;
+    // Clear the notFound flag when re-searching a publication number.
+    // If the notice has since been published, the fresh query will
+    // produce triples and the flag should not linger from a prior miss.
+    if (facets[index].notFound) {
+      delete facets[index].notFound;
+    }
     return facets[index];
   }
 

--- a/src/js/SearchPanel.js
+++ b/src/js/SearchPanel.js
@@ -291,6 +291,7 @@ export class SearchPanel {
     const a = document.createElement('a');
     a.className = 'dropdown-item';
     if (isActive) a.classList.add('active');
+    if (facet.notFound) a.classList.add('text-muted');
     a.href = '#';
 
     const label = document.createElement('div');
@@ -301,6 +302,12 @@ export class SearchPanel {
       v.className = isActive ? 'text-white-50 ms-1' : 'text-muted ms-1';
       v.textContent = `v${facet.noticeVersion}`;
       label.appendChild(v);
+    }
+    if (facet.notFound) {
+      const badge = document.createElement('span');
+      badge.className = 'badge bg-secondary ms-2';
+      badge.textContent = 'not found';
+      label.appendChild(badge);
     }
     a.appendChild(label);
 

--- a/src/js/SearchPanel.js
+++ b/src/js/SearchPanel.js
@@ -291,21 +291,20 @@ export class SearchPanel {
     const a = document.createElement('a');
     a.className = 'dropdown-item';
     if (isActive) a.classList.add('active');
-    if (facet.notFound) a.classList.add('text-muted');
     a.href = '#';
 
     const label = document.createElement('div');
-    label.className = 'fw-semibold';
+    label.className = 'fw-semibold d-flex align-items-center';
     label.textContent = getLabel(facet);
     if (facet.noticeVersion > 1) {
       const v = document.createElement('small');
-      v.className = isActive ? 'text-white-50 ms-1' : 'text-muted ms-1';
+      v.className = 'text-muted ms-1';
       v.textContent = `v${facet.noticeVersion}`;
       label.appendChild(v);
     }
     if (facet.notFound) {
       const badge = document.createElement('span');
-      badge.className = 'badge bg-secondary ms-2';
+      badge.className = 'badge badge-not-found ms-2';
       badge.textContent = 'not found';
       label.appendChild(badge);
     }
@@ -314,7 +313,7 @@ export class SearchPanel {
     const metaText = this._buildHistoryItemMetaText(facet);
     if (metaText) {
       const meta = document.createElement('small');
-      meta.className = isActive ? 'text-white-50' : 'text-muted';
+      meta.className = 'text-muted';
       meta.textContent = metaText;
       a.appendChild(meta);
     }

--- a/test/ExplorerController.test.js
+++ b/test/ExplorerController.test.js
@@ -406,6 +406,39 @@ test('removeFacetByValue persists the removal to sessionStorage', () => {
   );
 });
 
+// ── markFacetNotFound (not-found history tracking) ───────────────
+
+test('markFacetNotFound sets notFound flag on the matching facet', async () => {
+  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  assert.equal(controller.facetsList[0].notFound, undefined);
+
+  controller.markFacetNotFound('00172531-2026');
+  assert.equal(controller.facetsList[0].notFound, true);
+  assert.equal(controller.facetsList.length, 1, 'facet should remain in history, not be removed');
+});
+
+test('markFacetNotFound persists the flag to sessionStorage', async () => {
+  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  controller.markFacetNotFound('00172531-2026');
+
+  const stored = JSON.parse(globalThis.sessionStorage.getItem('explorer-facets-v3'));
+  assert.equal(stored[0].notFound, true, 'notFound flag should be persisted');
+});
+
+test('re-searching a not-found notice clears the notFound flag', async () => {
+  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  controller.markFacetNotFound('00172531-2026');
+  assert.equal(controller.facetsList[0].notFound, true);
+
+  // Re-search the same notice — _addToHistory should clear the flag
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  assert.equal(controller.facetsList[0].notFound, undefined,
+    'notFound flag should be cleared on re-search');
+});
+
 // ── Identity preservation (M1 + M6) ──────────────────────────────
 
 test('identity: breadcrumb[0] is the same reference as facetsList[0] after search', async () => {

--- a/test/ExplorerController.test.js
+++ b/test/ExplorerController.test.js
@@ -352,60 +352,6 @@ test('_loadFromSession returns empty list for corrupted JSON', () => {
   assert.equal(controller.facetsList.length, 0);
 });
 
-// ── removeFacetByValue (phantom history cleanup) ─────────────────
-
-test('removeFacetByValue removes a notice-number entry by publication number', async () => {
-  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
-  await controller.search(createPublicationNumberFacet(PUB_A));
-  await controller.search(createPublicationNumberFacet(PUB_B));
-  assert.equal(controller.facetsList.length, 2);
-
-  controller.removeFacetByValue('00172531-2026');
-  assert.equal(controller.facetsList.length, 1);
-  assert.equal(controller.facetsList[0].value, '00149228-2024');
-});
-
-test('removeFacetByValue is a no-op when no entry matches', () => {
-  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
-  controller.facetsList = [createPublicationNumberFacet(PUB_A)];
-  controller.removeFacetByValue('99999999-9999');
-  assert.equal(controller.facetsList.length, 1, 'list should be unchanged');
-});
-
-test('removeFacetByValue only matches notice-number facets, not other types with the same value field', () => {
-  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
-  // Seed the list directly (bypassing validation) with a hypothetical
-  // non-notice entry that happens to carry the same string in a
-  // 'value' field. removeFacetByValue must ignore it.
-  controller.facetsList = [
-    { type: 'query', value: '00172531-2026', query: 'SELECT * WHERE { ?s ?p ?o }' },
-    createPublicationNumberFacet('00172531-2026'),
-  ];
-  controller.removeFacetByValue('00172531-2026');
-  assert.equal(controller.facetsList.length, 1);
-  assert.equal(controller.facetsList[0].type, 'query');
-});
-
-test('removeFacetByValue persists the removal to sessionStorage', () => {
-  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
-  controller.facetsList = [
-    createPublicationNumberFacet(PUB_A),
-    createPublicationNumberFacet(PUB_B),
-  ];
-  controller._saveToSession();
-  assert.equal(
-    JSON.parse(globalThis.sessionStorage.getItem('explorer-facets-v3')).length,
-    2,
-  );
-
-  controller.removeFacetByValue('00172531-2026');
-  assert.equal(
-    JSON.parse(globalThis.sessionStorage.getItem('explorer-facets-v3')).length,
-    1,
-    'sessionStorage should reflect the removal',
-  );
-});
-
 // ── markFacetNotFound (not-found history tracking) ───────────────
 
 test('markFacetNotFound sets notFound flag on the matching facet', async () => {
@@ -427,16 +373,74 @@ test('markFacetNotFound persists the flag to sessionStorage', async () => {
   assert.equal(stored[0].notFound, true, 'notFound flag should be persisted');
 });
 
-test('re-searching a not-found notice clears the notFound flag', async () => {
-  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
+test('a successful re-search (non-empty result) clears the notFound flag', async () => {
+  let found = false;
+  const controller = new ExplorerController({
+    doSPARQL: async () => (found
+      ? { quads: [], size: 5, rawTurtle: 'x' }
+      : { quads: [], size: 0, rawTurtle: '' }),
+  });
   await controller.search(createPublicationNumberFacet(PUB_A));
   controller.markFacetNotFound('00172531-2026');
   assert.equal(controller.facetsList[0].notFound, true);
 
-  // Re-search the same notice — _addToHistory should clear the flag
+  // The notice has since been published: a re-search returns data, so the
+  // flag is cleared.
+  found = true;
   await controller.search(createPublicationNumberFacet(PUB_A));
   assert.equal(controller.facetsList[0].notFound, undefined,
-    'notFound flag should be cleared on re-search');
+    'notFound should be cleared once the notice returns data');
+  const stored = JSON.parse(globalThis.sessionStorage.getItem('explorer-facets-v3'));
+  assert.equal(stored[0].notFound, undefined,
+    'the cleared flag is persisted, so the badge does not return on reload');
+});
+
+test('an empty re-search keeps the notFound flag (notice still not found)', async () => {
+  const controller = new ExplorerController({
+    doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }),
+  });
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  controller.markFacetNotFound('00172531-2026');
+  assert.equal(controller.facetsList[0].notFound, true);
+
+  // Re-search while still empty — the flag must NOT be cleared.
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  assert.equal(controller.facetsList[0].notFound, true,
+    'notFound must persist while the notice still returns nothing');
+});
+
+test('a failed re-search does not clear the notFound flag', async () => {
+  // Regression guard: clearing the flag at search START would wipe the badge
+  // on a retry that errors, is cancelled, or the tab closes mid-flight —
+  // even though the notice was never actually found.
+  let fail = false;
+  const controller = new ExplorerController({
+    doSPARQL: async () => {
+      if (fail) throw new Error('network down');
+      return { quads: [], size: 0, rawTurtle: '' };
+    },
+  });
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  controller.markFacetNotFound('00172531-2026');
+  assert.equal(controller.facetsList[0].notFound, true);
+
+  fail = true;
+  await controller.search(createPublicationNumberFacet(PUB_A));
+  assert.equal(controller.facetsList[0].notFound, true,
+    'a failed retry must leave the not-found badge in place');
+  assert.ok(controller.error, 'the failed retry surfaces an error');
+});
+
+test('markFacetNotFound survives a reload: _loadFromSession preserves the flag', () => {
+  // The badge must persist across a page reload — _loadFromSession runs every
+  // stored facet through validateFacet, which must carry notFound through.
+  globalThis.sessionStorage.setItem('explorer-facets-v3', JSON.stringify([
+    { type: 'notice-number', value: '00172531-2026', timestamp: 1, notFound: true },
+  ]));
+  const controller = new ExplorerController({ doSPARQL: async () => ({ quads: [], size: 0, rawTurtle: '' }) });
+  assert.equal(controller.facetsList.length, 1);
+  assert.equal(controller.facetsList[0].notFound, true,
+    'notFound should survive the sessionStorage round-trip');
 });
 
 // ── Identity preservation (M1 + M6) ──────────────────────────────

--- a/test/SearchPanel.test.js
+++ b/test/SearchPanel.test.js
@@ -164,3 +164,34 @@ test('SearchPanel still corrects the editor when the editor reader is not wired'
   assert.ok(writes.some((t) => t.includes('hasIdentifierValue')),
     'without an editor reader, the fallback query is still reflected');
 });
+
+// ── "not found" chip in the history dropdown (issue #79) ─────────
+
+// Walk the stub-element tree (the DOM shim exposes appended children on
+// `_children`) and return the first element whose className matches.
+function findByClass(el, cls) {
+  for (const child of el._children || []) {
+    if ((child.className || '').includes(cls)) return child;
+    const nested = findByClass(child, cls);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+test('a not-found history item renders a "not found" chip', () => {
+  const controller = new ExplorerController({ doSPARQL: async () => EMPTY_RESULT });
+  const panel = new SearchPanel(controller, {});
+  const li = panel._buildHistoryItem({ type: 'notice-number', value: '00172531-2026', notFound: true }, false);
+
+  const chip = findByClass(li, 'badge-not-found');
+  assert.ok(chip, 'a not-found item should render the chip');
+  assert.equal(chip.textContent, 'not found');
+});
+
+test('a found history item renders no "not found" chip', () => {
+  const controller = new ExplorerController({ doSPARQL: async () => EMPTY_RESULT });
+  const panel = new SearchPanel(controller, {});
+  const li = panel._buildHistoryItem({ type: 'notice-number', value: '00172531-2026' }, false);
+
+  assert.equal(findByClass(li, 'badge-not-found'), null, 'no chip for a found notice');
+});


### PR DESCRIPTION
Instead of removing a publication number from history when it is not found in the triplestore, mark it with a notFound flag and display a 'not found' badge in the history dropdown. The flag is cleared on re-search so that if data becomes available later, the badge disappears.

Closes #79