### PR TITLE
Add chart visualization using Apache ECharts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A web-based tool for exploring TED Open Data — the public procurement data published by the Publications Office of the EU as Linked Open Data. The app combines two complementary workflows over the same RDF backend:
 
 - **Look up an individual notice** by its publication number and inspect its full RDF graph as a navigable tree, raw Turtle, or backlinks view. Procedure timeline, breadcrumb navigation, drill-into-resource, and shareable URLs included.
-- **Write SPARQL queries** against the entire dataset using a CodeMirror 6 editor with ePO-aware autocomplete and syntax linting. SELECT and ASK results render as a table; CONSTRUCT and DESCRIBE results render as the same RDF graph view used by notice lookup.
+- **Write SPARQL queries** against the entire dataset using a CodeMirror 6 editor with ePO-aware autocomplete and syntax linting. SELECT and ASK results render as a table or an interactive chart (bar, line, pie, scatter); CONSTRUCT and DESCRIBE results render as the same RDF graph view used by notice lookup.
 
 The two workflows share a single **Reuse** tab that auto-picks the right rendering based on the query type (tabular for SELECT/ASK, graph for CONSTRUCT/DESCRIBE).
 
@@ -13,6 +13,7 @@ The two workflows share a single **Reuse** tab that auto-picks the right renderi
 - **Procedure timeline**: see all sibling notices in the same procurement procedure with one click
 - **SPARQL editor** with ePO autocomplete, syntax linting, and a curated query library
 - **Auto-routing by query type**: SELECT/ASK → tabular results, CONSTRUCT/DESCRIBE → tree/turtle/backlinks
+- **Chart SELECT results** as bar, line, pie, or scatter charts with selectable X/Y axes and grouping
 - **Shareable URLs** for any notice or sub-resource view (`?facet=…`)
 - **Multiple result formats** for SELECT (JSON, HTML, XML, CSV, TSV, Spreadsheet) and graph downloads (Turtle, RDF/XML, N-Triples)
 - **Reusable query URLs** for embedding into Excel, Power BI, etc.
@@ -132,6 +133,11 @@ This project uses the following third-party components:
   - Purpose: Icon library
   - License: MIT
   - Website: https://icons.getbootstrap.com/
+
+- **Apache ECharts** (v5.6.0)
+  - Purpose: Interactive charts for SELECT query results (Reuse tab → Chart view)
+  - License: Apache-2.0
+  - Website: https://echarts.apache.org/
 
 - **CodeMirror** (v6)
   - Purpose: Code editor

--- a/index.html
+++ b/index.html
@@ -503,33 +503,6 @@
                         <i class="bi bi-play-circle"></i>
                     </button>
                 </span>
-                <div id="results-view-toggle" class="d-none d-flex align-items-center gap-2 flex-wrap">
-                    <div class="btn-group btn-group-sm" role="group" aria-label="Switch between table and chart view">
-                        <input type="radio" class="btn-check" name="results-view" id="results-view-table" value="table" checked>
-                        <label class="btn btn-outline-secondary px-4" for="results-view-table">
-                            <i class="bi bi-table"></i> Table
-                        </label>
-                        <input type="radio" class="btn-check" name="results-view" id="results-view-chart" value="chart">
-                        <label class="btn btn-outline-secondary px-4" for="results-view-chart">
-                            <i class="bi bi-bar-chart"></i> Chart
-                        </label>
-                    </div>
-                    <div id="chart-settings" class="d-none d-flex align-items-center gap-2 ms-2 flex-wrap">
-                        <label for="chart-type-select" class="small text-muted mb-0">Type:</label>
-                        <select id="chart-type-select" class="form-select form-select-sm" style="width: auto;">
-                            <option value="bar">Bar</option>
-                            <option value="line">Line</option>
-                            <option value="pie">Pie</option>
-                            <option value="scatter">Scatter</option>
-                        </select>
-                        <label for="chart-x-select" class="small text-muted mb-0 ms-2">X:</label>
-                        <select id="chart-x-select" class="form-select form-select-sm" style="width: auto;"></select>
-                        <label for="chart-y-select" class="small text-muted mb-0 ms-2">Y:</label>
-                        <select id="chart-y-select" class="form-select form-select-sm" style="width: auto;"></select>
-                        <label for="chart-group-select" class="small text-muted mb-0 ms-2">Group:</label>
-                        <select id="chart-group-select" class="form-select form-select-sm" style="width: auto;"></select>
-                    </div>
-                </div>
                 <div class="results-toolbar-actions">
                     <button type="button" id="copy-url-button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-rocket-takeoff"></i> Copy endpoint URL</button>
                     <div class="dropdown d-inline-block">
@@ -544,6 +517,18 @@
                             <li><a class="dropdown-item" href="#" data-download-format="application/vnd.ms-excel">Spreadsheet</a></li>
                             <li><a class="dropdown-item" href="#" data-download-format="application/sparql-results+xml">XML</a></li>
                         </ul>
+                    </div>
+                    <div id="results-view-toggle" class="d-none d-flex align-items-center ms-2">
+                        <div class="btn-group btn-group-sm" role="group" aria-label="Switch between table and chart view">
+                            <input type="radio" class="btn-check" name="results-view" id="results-view-table" value="table" checked>
+                            <label class="btn btn-outline-secondary px-4" for="results-view-table">
+                                <i class="bi bi-table"></i> Table
+                            </label>
+                            <input type="radio" class="btn-check" name="results-view" id="results-view-chart" value="chart">
+                            <label class="btn btn-outline-secondary px-4" for="results-view-chart">
+                                <i class="bi bi-bar-chart"></i> Chart
+                            </label>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -573,6 +558,29 @@
             <!-- Results Section -->
             <div id="results">
                 <p class="text-muted">Query results will appear here...</p>
+            </div>
+            <div id="chart-settings" class="d-none d-flex align-items-center justify-content-end gap-3 flex-wrap my-3 px-2">
+                <div class="d-flex align-items-center gap-1">
+                    <label for="chart-type-select" class="small text-muted mb-0">Type:</label>
+                    <select id="chart-type-select" class="form-select form-select-sm" style="width: auto;">
+                        <option value="bar">Bar</option>
+                        <option value="line">Line</option>
+                        <option value="pie">Pie</option>
+                        <option value="scatter">Scatter</option>
+                    </select>
+                </div>
+                <div class="d-flex align-items-center gap-1">
+                    <label for="chart-x-select" class="small text-muted mb-0">X:</label>
+                    <select id="chart-x-select" class="form-select form-select-sm" style="width: auto;"></select>
+                </div>
+                <div class="d-flex align-items-center gap-1">
+                    <label for="chart-y-select" class="small text-muted mb-0">Y:</label>
+                    <select id="chart-y-select" class="form-select form-select-sm" style="width: auto;"></select>
+                </div>
+                <div class="d-flex align-items-center gap-1">
+                    <label for="chart-group-select" class="small text-muted mb-0">Group:</label>
+                    <select id="chart-group-select" class="form-select form-select-sm" style="width: auto;"></select>
+                </div>
             </div>
             <div id="chart-container" class="d-none" style="width: 100%; height: 500px;"></div>
         </div> <!-- Close query-results div -->
@@ -792,7 +800,7 @@
                             <li>Use the <b>Query Library</b> tab to explore suggested SPARQL queries. These will help you get started.</li>
                             <li>Use the <b>Query Editor</b> tab to compose your SPARQL query.</li>
                             <li>To test your query use the <b>Run Query</b> button.</li>
-                            <li>SELECT and ASK results are displayed in the <b>Query Results</b> tab as a table.</li>
+                            <li>SELECT and ASK results are displayed in the <b>Query Results</b> tab as a table — or as an interactive chart (bar, line, pie, scatter) via the <b>Table / Chart</b> toggle when the results are chartable.</li>
                             <li>CONSTRUCT and DESCRIBE results are displayed in the <b>Query Results</b> tab as an RDF graph (the same tree/turtle/backlinks view used by notice lookup).</li>
                             <li>For SELECT queries you can get a URL that runs the query directly by clicking on the <b>Copy URL</b> button.<br/>
                                 You can use this URL to run your query and retrieve live results directly into <b>Excel</b>, <b>Power BI</b>, or any application that can get data from the web.</li>
@@ -1035,8 +1043,10 @@
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
 
-    <!-- Apache ECharts — rich interactive charting for query results visualization -->
-    <script src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"></script>
+    <!-- Apache ECharts (query-results charting) is ~1 MB, so it is lazy-loaded
+         on the first switch to Chart view by ChartView._loadECharts() rather
+         than shipped to every page load. -->
+
 
     <!-- N3 (Turtle parser) — used by the ported explorer modules
          (sparqlService.js parses CONSTRUCT/DESCRIBE results into quads).

--- a/index.html
+++ b/index.html
@@ -544,9 +544,37 @@
             </div>
 
             <!-- Results Section -->
+            <div id="results-view-toggle" class="d-none mb-2 mt-2 d-flex align-items-center gap-2 flex-wrap">
+                <div class="btn-group btn-group-sm" role="group" aria-label="Switch between table and chart view">
+                    <input type="radio" class="btn-check" name="results-view" id="results-view-table" value="table" checked>
+                    <label class="btn btn-outline-secondary" for="results-view-table">
+                        <i class="bi bi-table"></i> Table
+                    </label>
+                    <input type="radio" class="btn-check" name="results-view" id="results-view-chart" value="chart">
+                    <label class="btn btn-outline-secondary" for="results-view-chart">
+                        <i class="bi bi-bar-chart"></i> Chart
+                    </label>
+                </div>
+                <div id="chart-settings" class="d-none d-flex align-items-center gap-2 ms-2 flex-wrap">
+                    <label for="chart-type-select" class="small text-muted mb-0">Type:</label>
+                    <select id="chart-type-select" class="form-select form-select-sm" style="width: auto;">
+                        <option value="bar">Bar</option>
+                        <option value="line">Line</option>
+                        <option value="pie">Pie</option>
+                        <option value="scatter">Scatter</option>
+                    </select>
+                    <label for="chart-x-select" class="small text-muted mb-0 ms-2">X:</label>
+                    <select id="chart-x-select" class="form-select form-select-sm" style="width: auto;"></select>
+                    <label for="chart-y-select" class="small text-muted mb-0 ms-2">Y:</label>
+                    <select id="chart-y-select" class="form-select form-select-sm" style="width: auto;"></select>
+                    <label for="chart-group-select" class="small text-muted mb-0 ms-2">Group:</label>
+                    <select id="chart-group-select" class="form-select form-select-sm" style="width: auto;"></select>
+                </div>
+            </div>
             <div id="results">
                 <p class="text-muted">Query results will appear here...</p>
             </div>
+            <div id="chart-container" class="d-none" style="width: 100%; height: 500px;"></div>
         </div> <!-- Close query-results div -->
 
         <!-- ═══ EXPLORE TAB ═══ -->
@@ -1006,6 +1034,9 @@
 
     <!-- Bootstrap JS Bundle -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Apache ECharts — rich interactive charting for query results visualization -->
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js"></script>
 
     <!-- N3 (Turtle parser) — used by the ported explorer modules
          (sparqlService.js parses CONSTRUCT/DESCRIBE results into quads).

--- a/index.html
+++ b/index.html
@@ -503,6 +503,33 @@
                         <i class="bi bi-play-circle"></i>
                     </button>
                 </span>
+                <div id="results-view-toggle" class="d-none d-flex align-items-center gap-2 flex-wrap">
+                    <div class="btn-group btn-group-sm" role="group" aria-label="Switch between table and chart view">
+                        <input type="radio" class="btn-check" name="results-view" id="results-view-table" value="table" checked>
+                        <label class="btn btn-outline-secondary px-4" for="results-view-table">
+                            <i class="bi bi-table"></i> Table
+                        </label>
+                        <input type="radio" class="btn-check" name="results-view" id="results-view-chart" value="chart">
+                        <label class="btn btn-outline-secondary px-4" for="results-view-chart">
+                            <i class="bi bi-bar-chart"></i> Chart
+                        </label>
+                    </div>
+                    <div id="chart-settings" class="d-none d-flex align-items-center gap-2 ms-2 flex-wrap">
+                        <label for="chart-type-select" class="small text-muted mb-0">Type:</label>
+                        <select id="chart-type-select" class="form-select form-select-sm" style="width: auto;">
+                            <option value="bar">Bar</option>
+                            <option value="line">Line</option>
+                            <option value="pie">Pie</option>
+                            <option value="scatter">Scatter</option>
+                        </select>
+                        <label for="chart-x-select" class="small text-muted mb-0 ms-2">X:</label>
+                        <select id="chart-x-select" class="form-select form-select-sm" style="width: auto;"></select>
+                        <label for="chart-y-select" class="small text-muted mb-0 ms-2">Y:</label>
+                        <select id="chart-y-select" class="form-select form-select-sm" style="width: auto;"></select>
+                        <label for="chart-group-select" class="small text-muted mb-0 ms-2">Group:</label>
+                        <select id="chart-group-select" class="form-select form-select-sm" style="width: auto;"></select>
+                    </div>
+                </div>
                 <div class="results-toolbar-actions">
                     <button type="button" id="copy-url-button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-rocket-takeoff"></i> Copy endpoint URL</button>
                     <div class="dropdown d-inline-block">
@@ -544,33 +571,6 @@
             </div>
 
             <!-- Results Section -->
-            <div id="results-view-toggle" class="d-none mb-2 mt-2 d-flex align-items-center gap-2 flex-wrap">
-                <div class="btn-group btn-group-sm" role="group" aria-label="Switch between table and chart view">
-                    <input type="radio" class="btn-check" name="results-view" id="results-view-table" value="table" checked>
-                    <label class="btn btn-outline-secondary" for="results-view-table">
-                        <i class="bi bi-table"></i> Table
-                    </label>
-                    <input type="radio" class="btn-check" name="results-view" id="results-view-chart" value="chart">
-                    <label class="btn btn-outline-secondary" for="results-view-chart">
-                        <i class="bi bi-bar-chart"></i> Chart
-                    </label>
-                </div>
-                <div id="chart-settings" class="d-none d-flex align-items-center gap-2 ms-2 flex-wrap">
-                    <label for="chart-type-select" class="small text-muted mb-0">Type:</label>
-                    <select id="chart-type-select" class="form-select form-select-sm" style="width: auto;">
-                        <option value="bar">Bar</option>
-                        <option value="line">Line</option>
-                        <option value="pie">Pie</option>
-                        <option value="scatter">Scatter</option>
-                    </select>
-                    <label for="chart-x-select" class="small text-muted mb-0 ms-2">X:</label>
-                    <select id="chart-x-select" class="form-select form-select-sm" style="width: auto;"></select>
-                    <label for="chart-y-select" class="small text-muted mb-0 ms-2">Y:</label>
-                    <select id="chart-y-select" class="form-select form-select-sm" style="width: auto;"></select>
-                    <label for="chart-group-select" class="small text-muted mb-0 ms-2">Group:</label>
-                    <select id="chart-group-select" class="form-select form-select-sm" style="width: auto;"></select>
-                </div>
-            </div>
             <div id="results">
                 <p class="text-muted">Query results will appear here...</p>
             </div>

--- a/src/js/ChartView.js
+++ b/src/js/ChartView.js
@@ -109,6 +109,8 @@ export class ChartView {
     this.chartContainer.classList.add('d-none');
     this.chartSettings.classList.add('d-none');
     this.viewToggle.classList.add('d-none');
+    // Ensure the results table is visible again when the chart is destroyed
+    this.resultsDiv.classList.remove('d-none');
     this.currentData = null;
   }
 

--- a/src/js/ChartView.js
+++ b/src/js/ChartView.js
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2024 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+
+/**
+ * ChartView — renders SPARQL SELECT results as interactive charts using Apache ECharts.
+ *
+ * Detects chartable data (at least one numeric column and one label column),
+ * and renders bar/line/pie/scatter charts with user-selectable axes, chart type,
+ * and an optional group-by column that splits data into multiple series.
+ */
+export class ChartView {
+  constructor() {
+    this.viewToggle = document.getElementById('results-view-toggle');
+    this.tableRadio = document.getElementById('results-view-table');
+    this.chartRadio = document.getElementById('results-view-chart');
+    this.chartSettings = document.getElementById('chart-settings');
+    this.chartTypeSelect = document.getElementById('chart-type-select');
+    this.xSelect = document.getElementById('chart-x-select');
+    this.ySelect = document.getElementById('chart-y-select');
+    this.groupSelect = document.getElementById('chart-group-select');
+    this.resultsDiv = document.getElementById('results');
+    this.chartContainer = document.getElementById('chart-container');
+    this.chart = null;
+    this.currentData = null;
+    this.headers = [];
+
+    this._initEventListeners();
+    this._initResizeObserver();
+  }
+
+  _initEventListeners() {
+    this.tableRadio.addEventListener('change', () => this._onViewChange());
+    this.chartRadio.addEventListener('change', () => this._onViewChange());
+    this.chartTypeSelect.addEventListener('change', () => this._renderChart());
+    this.xSelect.addEventListener('change', () => this._renderChart());
+    this.ySelect.addEventListener('change', () => this._renderChart());
+    this.groupSelect.addEventListener('change', () => this._renderChart());
+  }
+
+  _initResizeObserver() {
+    // ECharts needs explicit resize calls when its container changes size
+    const observer = new ResizeObserver(() => {
+      if (this.chart) this.chart.resize();
+    });
+    observer.observe(this.chartContainer);
+  }
+
+  /**
+   * Analyse SPARQL JSON results and enable chart view if the data is chartable.
+   * Called by QueryResults after displaying the table.
+   * @param {Object} data - The SPARQL results JSON (data.results.bindings).
+   */
+  setData(data) {
+    this.destroy();
+
+    if (!data?.results?.bindings?.length) {
+      this.viewToggle.classList.add('d-none');
+      this.currentData = null;
+      return;
+    }
+
+    const bindings = data.results.bindings;
+    this.headers = Object.keys(bindings[0]);
+    this.currentData = bindings;
+
+    // Detect which columns are numeric (candidate Y axes)
+    const numericColumns = this.headers.filter(h =>
+      bindings.every(row => {
+        const val = row[h]?.value;
+        return val !== undefined && val !== '' && !isNaN(Number(val));
+      })
+    );
+
+    // Detect which columns are non-numeric (candidate X axes and group-by)
+    const labelColumns = this.headers.filter(h => !numericColumns.includes(h));
+
+    // Need at least one numeric and one label column to be chartable
+    if (numericColumns.length === 0 || labelColumns.length === 0) {
+      this.viewToggle.classList.add('d-none');
+      return;
+    }
+
+    // Populate axis selectors
+    this._populateSelect(this.xSelect, labelColumns);
+    this._populateSelect(this.ySelect, numericColumns);
+    this._populateGroupSelect(labelColumns);
+
+    // Show the toggle
+    this.viewToggle.classList.remove('d-none');
+
+    // Default to table view
+    this.tableRadio.checked = true;
+    this._onViewChange();
+  }
+
+  /**
+   * Destroy the current chart and hide chart UI.
+   */
+  destroy() {
+    if (this.chart) {
+      this.chart.dispose();
+      this.chart = null;
+    }
+    this.chartContainer.classList.add('d-none');
+    this.chartSettings.classList.add('d-none');
+    this.viewToggle.classList.add('d-none');
+    this.currentData = null;
+  }
+
+  _populateSelect(selectEl, options) {
+    selectEl.innerHTML = '';
+    options.forEach(opt => {
+      const option = document.createElement('option');
+      option.value = opt;
+      option.textContent = opt;
+      selectEl.appendChild(option);
+    });
+  }
+
+  _populateGroupSelect(labelColumns) {
+    this.groupSelect.innerHTML = '';
+    const noneOption = document.createElement('option');
+    noneOption.value = '';
+    noneOption.textContent = 'None';
+    this.groupSelect.appendChild(noneOption);
+    labelColumns.forEach(col => {
+      const option = document.createElement('option');
+      option.value = col;
+      option.textContent = col;
+      this.groupSelect.appendChild(option);
+    });
+  }
+
+  _onViewChange() {
+    const isChart = this.chartRadio.checked;
+    if (isChart) {
+      this.resultsDiv.classList.add('d-none');
+      this.chartContainer.classList.remove('d-none');
+      this.chartSettings.classList.remove('d-none');
+      this._renderChart();
+    } else {
+      this.resultsDiv.classList.remove('d-none');
+      this.chartContainer.classList.add('d-none');
+      this.chartSettings.classList.add('d-none');
+    }
+  }
+
+  _renderChart() {
+    if (!this.currentData || !this.currentData.length) return;
+
+    const xColumn = this.xSelect.value;
+    const yColumn = this.ySelect.value;
+    const groupColumn = this.groupSelect.value;
+    const chartType = this.chartTypeSelect.value;
+
+    // Initialize ECharts instance if not already created
+    if (!this.chart) {
+      this.chart = echarts.init(this.chartContainer);
+    }
+
+    let option;
+    if (groupColumn && groupColumn !== xColumn) {
+      option = this._buildGroupedOption(xColumn, yColumn, groupColumn, chartType);
+    } else {
+      option = this._buildSimpleOption(xColumn, yColumn, chartType);
+    }
+
+    this.chart.setOption(option, true); // true = replace, don't merge
+  }
+
+  _buildSimpleOption(xColumn, yColumn, chartType) {
+    // Aggregate Y values per unique X label
+    const aggregated = new Map();
+    this.currentData.forEach(row => {
+      const label = row[xColumn]?.value || '';
+      const value = Number(row[yColumn]?.value) || 0;
+      aggregated.set(label, (aggregated.get(label) || 0) + value);
+    });
+
+    const labels = [...aggregated.keys()];
+    const values = [...aggregated.values()];
+
+    if (chartType === 'pie') {
+      return {
+        title: { text: `${yColumn} by ${xColumn}`, left: 'center' },
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        legend: { type: 'scroll', bottom: 0 },
+        series: [{
+          type: 'pie',
+          radius: ['30%', '70%'],
+          data: labels.map((label, i) => ({ name: label, value: values[i] })),
+          emphasis: {
+            itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.3)' }
+          },
+          label: { formatter: '{b}: {d}%' },
+        }]
+      };
+    }
+
+    if (chartType === 'scatter') {
+      return {
+        title: { text: `${yColumn} by ${xColumn}`, left: 'center' },
+        tooltip: { trigger: 'item', formatter: (p) => `${p.name}: ${p.value[1]}` },
+        xAxis: { type: 'category', data: labels, name: xColumn, axisLabel: { rotate: 30 } },
+        yAxis: { type: 'value', name: yColumn },
+        dataZoom: labels.length > 10 ? [{ type: 'inside' }, { type: 'slider' }] : [{ type: 'inside' }],
+        series: [{
+          type: 'scatter',
+          data: values.map((v, i) => [labels[i], v]),
+          symbolSize: 10,
+          itemStyle: { color: '#2c862d' },
+        }]
+      };
+    }
+
+    // Bar or Line
+    return {
+      title: { text: `${yColumn} by ${xColumn}`, left: 'center' },
+      tooltip: { trigger: 'axis' },
+      xAxis: {
+        type: 'category',
+        data: labels,
+        name: xColumn,
+        axisLabel: { rotate: labels.length > 10 ? 30 : 0, overflow: 'truncate', width: 80 },
+      },
+      yAxis: { type: 'value', name: yColumn },
+      dataZoom: labels.length > 10 ? [{ type: 'inside' }, { type: 'slider' }] : [{ type: 'inside' }],
+      grid: { bottom: labels.length > 10 ? 80 : 60, containLabel: true },
+      series: [{
+        type: chartType,
+        data: values,
+        itemStyle: { color: '#2c862d' },
+        areaStyle: chartType === 'line' ? { opacity: 0.15 } : undefined,
+        smooth: chartType === 'line',
+      }]
+    };
+  }
+
+  _buildGroupedOption(xColumn, yColumn, groupColumn, chartType) {
+    // Collect unique X labels (preserving order of first appearance)
+    const labelsSet = new Set();
+    this.currentData.forEach(row => labelsSet.add(row[xColumn]?.value || ''));
+    const labels = [...labelsSet];
+
+    // Collect unique group values
+    const groupsSet = new Set();
+    this.currentData.forEach(row => groupsSet.add(row[groupColumn]?.value || ''));
+    const groups = [...groupsSet];
+
+    if (chartType === 'pie') {
+      // For pie with grouping, show total per group (ignoring X axis)
+      const groupTotals = new Map();
+      this.currentData.forEach(row => {
+        const group = row[groupColumn]?.value || '';
+        const value = Number(row[yColumn]?.value) || 0;
+        groupTotals.set(group, (groupTotals.get(group) || 0) + value);
+      });
+
+      return {
+        title: { text: `${yColumn} by ${groupColumn}`, left: 'center' },
+        tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
+        legend: { type: 'scroll', bottom: 0 },
+        series: [{
+          type: 'pie',
+          radius: ['30%', '70%'],
+          data: [...groupTotals.entries()].map(([name, value]) => ({ name, value })),
+          emphasis: {
+            itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.3)' }
+          },
+          label: { formatter: '{b}: {d}%' },
+        }]
+      };
+    }
+
+    // Build a series per group for bar/line/scatter
+    const series = groups.map(group => {
+      const data = labels.map(label => {
+        const row = this.currentData.find(r =>
+          (r[xColumn]?.value || '') === label &&
+          (r[groupColumn]?.value || '') === group
+        );
+        return row ? (Number(row[yColumn]?.value) || 0) : 0;
+      });
+
+      return {
+        name: group,
+        type: chartType === 'scatter' ? 'scatter' : chartType,
+        data: data,
+        smooth: chartType === 'line',
+        areaStyle: chartType === 'line' ? { opacity: 0.1 } : undefined,
+        symbolSize: chartType === 'scatter' ? 10 : undefined,
+      };
+    });
+
+    return {
+      title: { text: `${yColumn} by ${xColumn} (grouped by ${groupColumn})`, left: 'center' },
+      tooltip: { trigger: chartType === 'scatter' ? 'item' : 'axis' },
+      legend: { type: 'scroll', bottom: labels.length > 10 ? 40 : 0, data: groups },
+      xAxis: {
+        type: 'category',
+        data: labels,
+        name: xColumn,
+        axisLabel: { rotate: labels.length > 10 ? 30 : 0, overflow: 'truncate', width: 80 },
+      },
+      yAxis: { type: 'value', name: yColumn },
+      dataZoom: labels.length > 10 ? [{ type: 'inside' }, { type: 'slider', bottom: 10 }] : [{ type: 'inside' }],
+      grid: { bottom: labels.length > 10 ? 120 : 80, containLabel: true },
+      series: series,
+    };
+  }
+}

--- a/src/js/ChartView.js
+++ b/src/js/ChartView.js
@@ -12,6 +12,8 @@
  * the Licence.
  */
 
+import { classifyColumns, aggregateByX } from './utils/chartUtils.js';
+
 /**
  * ChartView — renders SPARQL SELECT results as interactive charts using Apache ECharts.
  *
@@ -75,15 +77,7 @@ export class ChartView {
     this.currentData = bindings;
 
     // Detect which columns are numeric (candidate Y axes)
-    const numericColumns = this.headers.filter(h =>
-      bindings.every(row => {
-        const val = row[h]?.value;
-        return val !== undefined && val !== '' && !isNaN(Number(val));
-      })
-    );
-
-    // Detect which columns are non-numeric (candidate X axes and group-by)
-    const labelColumns = this.headers.filter(h => !numericColumns.includes(h));
+    const { numericColumns, labelColumns } = classifyColumns(bindings);
 
     // Need at least one numeric and one label column to be chartable
     if (numericColumns.length === 0 || labelColumns.length === 0) {
@@ -181,15 +175,7 @@ export class ChartView {
 
   _buildSimpleOption(xColumn, yColumn, chartType) {
     // Aggregate Y values per unique X label
-    const aggregated = new Map();
-    this.currentData.forEach(row => {
-      const label = row[xColumn]?.value || '';
-      const value = Number(row[yColumn]?.value) || 0;
-      aggregated.set(label, (aggregated.get(label) || 0) + value);
-    });
-
-    const labels = [...aggregated.keys()];
-    const values = [...aggregated.values()];
+    const { labels, values } = aggregateByX(this.currentData, xColumn, yColumn);
 
     if (chartType === 'pie') {
       return {

--- a/src/js/ChartView.js
+++ b/src/js/ChartView.js
@@ -12,7 +12,7 @@
  * the Licence.
  */
 
-import { classifyColumns, aggregateByX } from './utils/chartUtils.js';
+import { classifyColumns, isChartable, aggregateByX, chartLabel } from './utils/chartUtils.js';
 
 /**
  * ChartView — renders SPARQL SELECT results as interactive charts using Apache ECharts.
@@ -72,23 +72,39 @@ export class ChartView {
       return;
     }
 
+    // ECharts is lazy-loaded on the first switch to Chart view, so it's
+    // normally absent here — that's fine, clicking the toggle triggers the
+    // load. A previous load failure is not latched: it may have been a
+    // transient CDN/network blip, so the toggle is still offered and the next
+    // click retries (a persistent failure just falls back to the table again).
     const bindings = data.results.bindings;
     this.headers = Object.keys(bindings[0]);
     this.currentData = bindings;
 
-    // Detect which columns are numeric (candidate Y axes)
-    const { numericColumns, labelColumns } = classifyColumns(bindings);
-
-    // Need at least one numeric and one label column to be chartable
-    if (numericColumns.length === 0 || labelColumns.length === 0) {
+    // Need at least one numeric and one label column to be chartable.
+    if (!isChartable(bindings)) {
       this.viewToggle.classList.add('d-none');
       return;
     }
 
+    // Numeric columns are candidate Y axes; label columns are candidate X / Group.
+    const { numericColumns, labelColumns } = classifyColumns(bindings);
+
+    // X axis prefers label columns, but falls back to the numeric columns when
+    // every column is numeric (e.g. `?year ?count`) so an all-numeric result
+    // still has an X axis to plot against.
+    const xColumns = labelColumns.length > 0 ? labelColumns : numericColumns;
+
     // Populate axis selectors
-    this._populateSelect(this.xSelect, labelColumns);
+    this._populateSelect(this.xSelect, xColumns);
     this._populateSelect(this.ySelect, numericColumns);
     this._populateGroupSelect(labelColumns);
+
+    // In the all-numeric case X and Y default to the same first column; nudge
+    // Y to a different one so the initial chart isn't a column against itself.
+    if (this.xSelect.value === this.ySelect.value && numericColumns.length > 1) {
+      this.ySelect.value = numericColumns.find(c => c !== this.xSelect.value);
+    }
 
     // Show the toggle
     this.viewToggle.classList.remove('d-none');
@@ -138,22 +154,90 @@ export class ChartView {
     });
   }
 
-  _onViewChange() {
+  async _onViewChange() {
     const isChart = this.chartRadio.checked;
-    if (isChart) {
-      this.resultsDiv.classList.add('d-none');
-      this.chartContainer.classList.remove('d-none');
-      this.chartSettings.classList.remove('d-none');
-      this._renderChart();
-    } else {
+    if (!isChart) {
       this.resultsDiv.classList.remove('d-none');
       this.chartContainer.classList.add('d-none');
       this.chartSettings.classList.add('d-none');
+      return;
     }
+
+    this.resultsDiv.classList.add('d-none');
+    this.chartContainer.classList.remove('d-none');
+    this.chartSettings.classList.remove('d-none');
+
+    // Lazy-load ECharts on the first switch to Chart view. Show a brief
+    // loading state while the ~1 MB script downloads; if it fails, drop back
+    // to the table and remove the toggle.
+    if (typeof echarts === 'undefined') {
+      this.chartContainer.innerHTML =
+        '<div class="d-flex justify-content-center align-items-center py-5 text-muted">' +
+        '<div class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></div>' +
+        'Loading chart…</div>';
+      try {
+        await ChartView._loadECharts();
+      } catch {
+        this._onEChartsUnavailable();
+        return;
+      }
+      // A newer query may have swapped the data out while we were loading.
+      if (!this.chartRadio.checked || !this.currentData) return;
+    }
+
+    this.chartContainer.innerHTML = '';
+    this._renderChart();
+  }
+
+  /**
+   * Fall back to the table when ECharts can't be loaded (CDN blocked /
+   * offline / CSP). Reverts to the table view for this attempt but leaves the
+   * toggle in place — the failure isn't latched, so if it was transient the
+   * next Chart click retries (`_loadECharts` cleared its cached promise).
+   */
+  _onEChartsUnavailable() {
+    if (!ChartView._echartsWarned) {
+      console.warn('[ChartView] Apache ECharts failed to load; showing the table. ' +
+        'The next switch to Chart view will retry.');
+      ChartView._echartsWarned = true;
+    }
+    this.chartContainer.innerHTML = '';
+    this.tableRadio.checked = true;
+    this.resultsDiv.classList.remove('d-none');
+    this.chartContainer.classList.add('d-none');
+    this.chartSettings.classList.add('d-none');
+  }
+
+  /**
+   * Inject the ECharts CDN script on demand and resolve once the global is
+   * available. Concurrent/repeat calls share one in-flight load; a failed
+   * load clears the cached promise so a later attempt can retry.
+   * @returns {Promise<void>}
+   */
+  static _loadECharts() {
+    if (typeof echarts !== 'undefined') return Promise.resolve();
+    if (ChartView._echartsPromise) return ChartView._echartsPromise;
+
+    ChartView._echartsPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = ChartView.ECHARTS_SRC;
+      script.async = true;
+      script.onload = () =>
+        typeof echarts !== 'undefined'
+          ? resolve()
+          : reject(new Error('ECharts global missing after script load'));
+      script.onerror = () => reject(new Error('Failed to load ECharts script'));
+      document.head.appendChild(script);
+    });
+    ChartView._echartsPromise.catch(() => { ChartView._echartsPromise = null; });
+    return ChartView._echartsPromise;
   }
 
   _renderChart() {
     if (!this.currentData || !this.currentData.length) return;
+    // Safety net — setData already hides the toggle when echarts is absent,
+    // so this normally can't be reached, but never call echarts.init on undefined.
+    if (typeof echarts === 'undefined') return;
 
     const xColumn = this.xSelect.value;
     const yColumn = this.ySelect.value;
@@ -183,7 +267,7 @@ export class ChartView {
       return {
         title: { text: `${yColumn} by ${xColumn}`, left: 'center' },
         tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
-        legend: { type: 'scroll', bottom: 0 },
+        legend: { type: 'scroll', bottom: 0, formatter: chartLabel },
         series: [{
           type: 'pie',
           radius: ['30%', '70%'],
@@ -191,23 +275,32 @@ export class ChartView {
           emphasis: {
             itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.3)' }
           },
-          label: { formatter: '{b}: {d}%' },
+          label: { formatter: (p) => `${chartLabel(p.name)}: ${p.percent}%` },
         }]
       };
     }
 
     if (chartType === 'scatter') {
+      // Scatter plots RAW points — every (x, y) row — so duplicate X values
+      // spread out vertically instead of collapsing into one aggregated sum
+      // (bar/line keep the sum; only scatter shows the distribution). The
+      // category axis still lists the unique X labels; points reference them
+      // by value, so rows sharing an X stack at that column.
+      const points = this.currentData.map(row => [
+        row[xColumn]?.value || '',
+        Number(row[yColumn]?.value) || 0,
+      ]);
       return {
         title: { text: `${yColumn} by ${xColumn}`, left: 'center' },
-        tooltip: { trigger: 'item', formatter: (p) => `${p.name}: ${p.value[1]}` },
-        xAxis: { type: 'category', data: labels, name: xColumn, axisLabel: { rotate: 30 } },
+        tooltip: { trigger: 'item', formatter: (p) => `${p.value[0]}: ${p.value[1]}` },
+        xAxis: { type: 'category', data: labels, name: xColumn, axisLabel: { rotate: 30, formatter: chartLabel } },
         yAxis: { type: 'value', name: yColumn },
         dataZoom: labels.length > 10 ? [{ type: 'inside' }, { type: 'slider' }] : [{ type: 'inside' }],
         series: [{
           type: 'scatter',
-          data: values.map((v, i) => [labels[i], v]),
-          symbolSize: 10,
-          itemStyle: { color: '#2c862d' },
+          data: points,
+          symbolSize: 8,
+          itemStyle: { color: '#2c862d', opacity: 0.6 },
         }]
       };
     }
@@ -220,7 +313,7 @@ export class ChartView {
         type: 'category',
         data: labels,
         name: xColumn,
-        axisLabel: { rotate: labels.length > 10 ? 30 : 0, overflow: 'truncate', width: 80 },
+        axisLabel: { rotate: labels.length > 10 ? 30 : 0, overflow: 'truncate', width: 80, formatter: chartLabel },
       },
       yAxis: { type: 'value', name: yColumn },
       dataZoom: labels.length > 10 ? [{ type: 'inside' }, { type: 'slider' }] : [{ type: 'inside' }],
@@ -258,7 +351,7 @@ export class ChartView {
       return {
         title: { text: `${yColumn} by ${groupColumn}`, left: 'center' },
         tooltip: { trigger: 'item', formatter: '{b}: {c} ({d}%)' },
-        legend: { type: 'scroll', bottom: 0 },
+        legend: { type: 'scroll', bottom: 0, formatter: chartLabel },
         series: [{
           type: 'pie',
           radius: ['30%', '70%'],
@@ -266,40 +359,54 @@ export class ChartView {
           emphasis: {
             itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.3)' }
           },
-          label: { formatter: '{b}: {d}%' },
+          label: { formatter: (p) => `${chartLabel(p.name)}: ${p.percent}%` },
         }]
       };
     }
 
-    // Build a series per group for bar/line/scatter
-    const series = groups.map(group => {
-      const data = labels.map(label => {
-        const row = this.currentData.find(r =>
-          (r[xColumn]?.value || '') === label &&
-          (r[groupColumn]?.value || '') === group
-        );
-        return row ? (Number(row[yColumn]?.value) || 0) : 0;
-      });
-
-      return {
+    // Build a series per group. Scatter and bar/line differ fundamentally:
+    // scatter shows the raw distribution; bar/line show one value per cell.
+    let series;
+    if (chartType === 'scatter') {
+      // Plot every group's raw (x, y) rows — no collapsing of duplicate
+      // (x, group) rows and no phantom y=0 point for missing cells.
+      series = groups.map(group => ({
         name: group,
-        type: chartType === 'scatter' ? 'scatter' : chartType,
-        data: data,
+        type: 'scatter',
+        symbolSize: 8,
+        itemStyle: { opacity: 0.6 },
+        data: this.currentData
+          .filter(r => (r[groupColumn]?.value || '') === group)
+          .map(r => [r[xColumn]?.value || '', Number(r[yColumn]?.value) || 0]),
+      }));
+    } else {
+      // Bar/line: sum Y per (x label × group), 0 for a missing cell — the same
+      // aggregation the ungrouped bar/line uses (aggregateByX), so duplicate
+      // (x, group) rows add up instead of the first one winning. Indexed once
+      // so the grid is O(rows + groups×labels), not O(groups × labels × rows).
+      const yByCell = new Map();
+      for (const r of this.currentData) {
+        const key = JSON.stringify([r[xColumn]?.value || '', r[groupColumn]?.value || '']);
+        yByCell.set(key, (yByCell.get(key) || 0) + (Number(r[yColumn]?.value) || 0));
+      }
+      series = groups.map(group => ({
+        name: group,
+        type: chartType,
+        data: labels.map(label => yByCell.get(JSON.stringify([label, group])) ?? 0),
         smooth: chartType === 'line',
         areaStyle: chartType === 'line' ? { opacity: 0.1 } : undefined,
-        symbolSize: chartType === 'scatter' ? 10 : undefined,
-      };
-    });
+      }));
+    }
 
     return {
       title: { text: `${yColumn} by ${xColumn} (grouped by ${groupColumn})`, left: 'center' },
       tooltip: { trigger: chartType === 'scatter' ? 'item' : 'axis' },
-      legend: { type: 'scroll', bottom: labels.length > 10 ? 40 : 0, data: groups },
+      legend: { type: 'scroll', bottom: labels.length > 10 ? 40 : 0, data: groups, formatter: chartLabel },
       xAxis: {
         type: 'category',
         data: labels,
         name: xColumn,
-        axisLabel: { rotate: labels.length > 10 ? 30 : 0, overflow: 'truncate', width: 80 },
+        axisLabel: { rotate: labels.length > 10 ? 30 : 0, overflow: 'truncate', width: 80, formatter: chartLabel },
       },
       yAxis: { type: 'value', name: yColumn },
       dataZoom: labels.length > 10 ? [{ type: 'inside' }, { type: 'slider', bottom: 10 }] : [{ type: 'inside' }],
@@ -308,3 +415,8 @@ export class ChartView {
     };
   }
 }
+
+// CDN source for the lazy-loaded ECharts bundle (see index.html — the eager
+// <script> was removed so this ~1 MB download only happens when a user first
+// opens a chart). Keep the version in sync with the README component list.
+ChartView.ECHARTS_SRC = 'https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js';

--- a/src/js/QueryResults.js
+++ b/src/js/QueryResults.js
@@ -17,6 +17,7 @@ import { triggerBlobDownload } from './utils/download.js';
 import { classifyError } from './utils/errorMessages.js';
 import { buildSparqlBody, buildSparqlUrl } from './sparqlRequest.js';
 import { showToast } from './utils/toast.js';
+import { ChartView } from './ChartView.js';
 
 /**
  * Class representing the Query Results.
@@ -35,6 +36,7 @@ export class QueryResults {
     this.copyUrlButton = document.getElementById('copy-url-button');
     this.copyUrlAlert = document.getElementById('copy-url-alert');
     this.queryResultsTab = new bootstrap.Tab(document.getElementById('query-results-tab'));
+    this.chartView = new ChartView();
 
     this.initEventListeners();
   }
@@ -112,6 +114,7 @@ export class QueryResults {
       td.textContent = String(data.boolean);
       this.resultsDiv.appendChild(table);
       this.setToolbarVisible(true);
+      this.chartView.destroy();
       return;
     }
 
@@ -140,9 +143,11 @@ export class QueryResults {
 
       this.resultsDiv.appendChild(table);
       this.setToolbarVisible(true);
+      this.chartView.setData(data);
     } else {
       this.resultsDiv.textContent = "No results found.";
       this.setToolbarVisible(false);
+      this.chartView.destroy();
     }
   }
 
@@ -171,6 +176,7 @@ export class QueryResults {
 
     this.resultsDiv.appendChild(pre);
     this.setToolbarVisible(true);
+    this.chartView.destroy();
   }
 
   /**

--- a/src/js/tours/reuseSelectTour.js
+++ b/src/js/tours/reuseSelectTour.js
@@ -17,7 +17,7 @@
 import { startTour } from './tour.js';
 
 export function startReuseSelectTour() {
-  startTour([
+  const steps = [
     {
       element: '#results',
       title: 'Your results',
@@ -26,6 +26,25 @@ export function startReuseSelectTour() {
         'variables you asked for in the SELECT clause.',
       placement: 'top',
     },
+  ];
+
+  // Only include the chart step when the Table/Chart toggle is actually
+  // visible (i.e. the results are chartable; ECharts itself loads on demand
+  // when the toggle is clicked). Otherwise the toggle is `d-none` and the
+  // popover would anchor to a hidden element.
+  const viewToggle = document.getElementById('results-view-toggle');
+  if (viewToggle && !viewToggle.classList.contains('d-none')) {
+    steps.push({
+      element: '#results-view-toggle',
+      title: 'Table or chart',
+      content:
+        'When your results have a numeric column, switch from the table to an interactive ' +
+        'chart — bar, line, pie or scatter — and choose which columns to plot on each axis.',
+      placement: 'bottom',
+    });
+  }
+
+  steps.push(
     {
       element: '#copy-url-button',
       title: 'Copy endpoint URL',
@@ -50,5 +69,7 @@ export function startReuseSelectTour() {
         'or visit the <strong>Explore</strong> tab to pick a different ready-made query from ' +
         'the library.',
     },
-  ]);
+  );
+
+  startTour(steps);
 }

--- a/src/js/utils/chartUtils.js
+++ b/src/js/utils/chartUtils.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+
+/**
+ * Classify SPARQL result columns as numeric or non-numeric (label).
+ * A column is numeric if every row has a non-empty value that parses as a number.
+ *
+ * @param {Array} bindings - The SPARQL results bindings array.
+ * @returns {{ numericColumns: string[], labelColumns: string[] }}
+ */
+export function classifyColumns(bindings) {
+  if (!bindings || bindings.length === 0) return { numericColumns: [], labelColumns: [] };
+
+  const headers = Object.keys(bindings[0]);
+  const numericColumns = headers.filter(h =>
+    bindings.every(row => {
+      const val = row[h]?.value;
+      return val !== undefined && val !== '' && !isNaN(Number(val));
+    })
+  );
+  const labelColumns = headers.filter(h => !numericColumns.includes(h));
+  return { numericColumns, labelColumns };
+}
+
+/**
+ * Determine if SPARQL result bindings are chartable.
+ * Requires at least one numeric column and one non-numeric column.
+ *
+ * @param {Array} bindings - The SPARQL results bindings array.
+ * @returns {boolean}
+ */
+export function isChartable(bindings) {
+  const { numericColumns, labelColumns } = classifyColumns(bindings);
+  return numericColumns.length > 0 && labelColumns.length > 0;
+}
+
+/**
+ * Aggregate Y values per unique X label by summing duplicates.
+ *
+ * @param {Array} bindings - The SPARQL results bindings array.
+ * @param {string} xColumn - The column to use as the X axis (labels).
+ * @param {string} yColumn - The column to use as the Y axis (values to sum).
+ * @returns {{ labels: string[], values: number[] }}
+ */
+export function aggregateByX(bindings, xColumn, yColumn) {
+  const aggregated = new Map();
+  bindings.forEach(row => {
+    const label = row[xColumn]?.value || '';
+    const value = Number(row[yColumn]?.value) || 0;
+    aggregated.set(label, (aggregated.get(label) || 0) + value);
+  });
+  return { labels: [...aggregated.keys()], values: [...aggregated.values()] };
+}

--- a/src/js/utils/chartUtils.js
+++ b/src/js/utils/chartUtils.js
@@ -12,6 +12,36 @@
  * the Licence.
  */
 
+import { shortLabel } from './namespaces.js';
+
+/**
+ * Short, human-readable label for a chart axis / legend value.
+ *
+ * URIs collapse to their local name so a URI-valued column doesn't render
+ * every axis tick as an identical shared prefix (e.g. every legal-basis URI
+ * as "http://publ…"). The full value stays available in tooltips.
+ *
+ *  - ePO-resource / known-namespace URIs use the app's shortLabel
+ *    ("Lot LOT-0001", "epo:Notice").
+ *  - Any other http(s) URI → the segment after the last "/" or "#".
+ *  - Non-URI values (codes, dates, plain strings) are returned unchanged.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
+export function chartLabel(value) {
+  if (value == null) return '';
+  const s = String(value);
+  const short = shortLabel(s);
+  if (short !== s) return short;
+  if (/^https?:\/\//i.test(s)) {
+    const trimmed = s.replace(/[/#]+$/, '');
+    const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('#'));
+    if (idx >= 0 && idx < trimmed.length - 1) return trimmed.slice(idx + 1);
+  }
+  return s;
+}
+
 /**
  * Classify SPARQL result columns as numeric or non-numeric (label).
  * A column is numeric if every row has a non-empty value that parses as a number.
@@ -35,14 +65,17 @@ export function classifyColumns(bindings) {
 
 /**
  * Determine if SPARQL result bindings are chartable.
- * Requires at least one numeric column and one non-numeric column.
+ * Requires at least one numeric column (a Y axis) and at least two columns
+ * total (so a distinct X axis exists). An all-numeric result is chartable —
+ * e.g. `?year ?count` plots count-by-year with a numeric column as the X axis.
  *
  * @param {Array} bindings - The SPARQL results bindings array.
  * @returns {boolean}
  */
 export function isChartable(bindings) {
-  const { numericColumns, labelColumns } = classifyColumns(bindings);
-  return numericColumns.length > 0 && labelColumns.length > 0;
+  if (!bindings || bindings.length === 0) return false;
+  const { numericColumns } = classifyColumns(bindings);
+  return numericColumns.length > 0 && Object.keys(bindings[0]).length >= 2;
 }
 
 /**

--- a/test/chartUtils.test.js
+++ b/test/chartUtils.test.js
@@ -16,7 +16,47 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { classifyColumns, isChartable, aggregateByX } from '../src/js/utils/chartUtils.js';
+import { classifyColumns, isChartable, aggregateByX, chartLabel } from '../src/js/utils/chartUtils.js';
+
+// ── chartLabel ─────────────────────────────────────────────────────
+
+test('chartLabel collapses an authority URI to its local name', () => {
+  // The bug this fixes: legal-basis URIs all share a long prefix, so an
+  // axis truncated to a fixed width shows an identical "http://publ…".
+  assert.equal(
+    chartLabel('http://publications.europa.eu/resource/authority/legal-basis/32014L0024'),
+    '32014L0024',
+  );
+});
+
+test('chartLabel distinguishes URIs that share a prefix', () => {
+  const base = 'http://publications.europa.eu/resource/authority/legal-basis/';
+  assert.notEqual(chartLabel(base + '32014L0024'), chartLabel(base + '32014L0025'));
+});
+
+test('chartLabel uses the fragment after a # for hash URIs', () => {
+  assert.equal(chartLabel('http://data.europa.eu/a4g/ontology#Notice'), 'epo:Notice');
+});
+
+test('chartLabel shortens ePO resource URIs to "Type id" via shortLabel', () => {
+  assert.equal(
+    chartLabel('http://data.europa.eu/a4g/resource/id_abc_Lot_LOT-0001'),
+    'Lot LOT-0001',
+  );
+});
+
+test('chartLabel leaves non-URI values untouched', () => {
+  assert.equal(chartLabel('45000000'), '45000000');       // CPV code
+  assert.equal(chartLabel('2024-11-06'), '2024-11-06');   // date
+  assert.equal(chartLabel('Belgium'), 'Belgium');         // plain string
+});
+
+test('chartLabel handles a trailing slash and empty / nullish input', () => {
+  assert.equal(chartLabel('http://example.org/foo/bar/'), 'bar');
+  assert.equal(chartLabel(''), '');
+  assert.equal(chartLabel(null), '');
+  assert.equal(chartLabel(undefined), '');
+});
 
 // ── classifyColumns ────────────────────────────────────────────────
 
@@ -64,11 +104,18 @@ test('isChartable returns false when all columns are strings', () => {
   assert.equal(isChartable(bindings), false);
 });
 
-test('isChartable returns false when all columns are numeric', () => {
+test('isChartable returns true when all columns are numeric', () => {
+  // A numeric column can serve as the X axis — e.g. `?year ?count` plots
+  // count-by-year, so an all-numeric two-column result is chartable.
   const bindings = [
-    { x: { value: '1' }, y: { value: '2' } },
-    { x: { value: '3' }, y: { value: '4' } },
+    { year: { value: '2020' }, count: { value: '145' } },
+    { year: { value: '2021' }, count: { value: '210' } },
   ];
+  assert.equal(isChartable(bindings), true);
+});
+
+test('isChartable returns false for a single numeric column (no X axis)', () => {
+  const bindings = [{ count: { value: '1' } }, { count: { value: '2' } }];
   assert.equal(isChartable(bindings), false);
 });
 

--- a/test/chartUtils.test.js
+++ b/test/chartUtils.test.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// chartUtils tests — column classification, chartability detection,
+// and Y-value aggregation logic used by ChartView.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyColumns, isChartable, aggregateByX } from '../src/js/utils/chartUtils.js';
+
+// ── classifyColumns ────────────────────────────────────────────────
+
+test('classifyColumns identifies numeric and label columns correctly', () => {
+  const bindings = [
+    { date: { value: '2026-01-01' }, count: { value: '42' } },
+    { date: { value: '2026-01-02' }, count: { value: '15' } },
+  ];
+  const { numericColumns, labelColumns } = classifyColumns(bindings);
+  assert.deepEqual(numericColumns, ['count']);
+  assert.deepEqual(labelColumns, ['date']);
+});
+
+test('classifyColumns treats a column with one non-numeric value as a label column', () => {
+  const bindings = [
+    { name: { value: 'Alice' }, score: { value: '10' } },
+    { name: { value: 'Bob' }, score: { value: 'N/A' } },
+  ];
+  const { numericColumns, labelColumns } = classifyColumns(bindings);
+  assert.deepEqual(numericColumns, []);
+  assert.deepEqual(labelColumns, ['name', 'score']);
+});
+
+test('classifyColumns returns empty arrays for empty bindings', () => {
+  const { numericColumns, labelColumns } = classifyColumns([]);
+  assert.deepEqual(numericColumns, []);
+  assert.deepEqual(labelColumns, []);
+});
+
+// ── isChartable ────────────────────────────────────────────────────
+
+test('isChartable returns true when at least one numeric and one label column exist', () => {
+  const bindings = [
+    { country: { value: 'DE' }, notices: { value: '500' } },
+    { country: { value: 'FR' }, notices: { value: '300' } },
+  ];
+  assert.equal(isChartable(bindings), true);
+});
+
+test('isChartable returns false when all columns are strings', () => {
+  const bindings = [
+    { name: { value: 'Alice' }, city: { value: 'Brussels' } },
+    { name: { value: 'Bob' }, city: { value: 'Paris' } },
+  ];
+  assert.equal(isChartable(bindings), false);
+});
+
+test('isChartable returns false when all columns are numeric', () => {
+  const bindings = [
+    { x: { value: '1' }, y: { value: '2' } },
+    { x: { value: '3' }, y: { value: '4' } },
+  ];
+  assert.equal(isChartable(bindings), false);
+});
+
+test('isChartable returns false for empty bindings', () => {
+  assert.equal(isChartable([]), false);
+  assert.equal(isChartable(null), false);
+});
+
+// ── aggregateByX ──────────────────────────────────────────────────
+
+test('aggregateByX sums Y values for duplicate X labels', () => {
+  const bindings = [
+    { date: { value: '2026-01-01' }, count: { value: '10' } },
+    { date: { value: '2026-01-01' }, count: { value: '20' } },
+    { date: { value: '2026-01-02' }, count: { value: '5' } },
+  ];
+  const { labels, values } = aggregateByX(bindings, 'date', 'count');
+  assert.deepEqual(labels, ['2026-01-01', '2026-01-02']);
+  assert.deepEqual(values, [30, 5]);
+});
+
+test('aggregateByX preserves order of first appearance', () => {
+  const bindings = [
+    { country: { value: 'FR' }, amount: { value: '100' } },
+    { country: { value: 'DE' }, amount: { value: '200' } },
+    { country: { value: 'FR' }, amount: { value: '50' } },
+  ];
+  const { labels, values } = aggregateByX(bindings, 'country', 'amount');
+  assert.deepEqual(labels, ['FR', 'DE']);
+  assert.deepEqual(values, [150, 200]);
+});
+
+test('aggregateByX treats non-numeric Y values as 0', () => {
+  const bindings = [
+    { name: { value: 'A' }, val: { value: 'abc' } },
+    { name: { value: 'A' }, val: { value: '10' } },
+  ];
+  const { labels, values } = aggregateByX(bindings, 'name', 'val');
+  assert.deepEqual(labels, ['A']);
+  assert.deepEqual(values, [10]);
+});


### PR DESCRIPTION
Adds interactive chart view (Bar, Line, Pie, Scatter) to the Reuse tab for SELECT query results. Uses Apache ECharts v5.6.0 (Apache 2.0 license). Features: auto-detection of chartable data, user-selectable X/Y axes and grouping column, aggregation when ungrouped, scroll-to-zoom, conditional dataZoom slider (>10 values), responsive resize, and non-overlapping legend/slider layout.

Closes #50