### PR TITLE
Remove Options menu from Customize tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -426,15 +426,6 @@
                 </div>
                 <p class="small text-muted mb-2" id="query-label">Compose or refine your query in SPARQL</p>
 
-                <!-- Hidden inputs for SPARQL endpoint options (read by sparqlRequest.js) -->
-                <div class="d-none">
-                    <input type="checkbox" id="strict" name="strict" checked>
-                    <input type="checkbox" id="debug" name="debug">
-                    <input type="checkbox" id="report" name="report">
-                    <input type="number" id="timeout" name="timeout">
-                    <input type="text" id="default-graph-uri" name="default-graph-uri">
-                </div>
-
                 <div class="flex-grow-1 d-flex flex-column">
                     <div class="form-group flex-grow-1 d-flex flex-column">
                         <div id="query" class="flex-grow-1" role="textbox" aria-labelledby="query-label" aria-multiline="true"></div>

--- a/index.html
+++ b/index.html
@@ -420,56 +420,19 @@
                     <button class="btn btn-sm btn-outline-secondary ms-1" type="button" id="clear-editor" title="Clear the editor">
                         <i class="bi bi-trash"></i> Clear
                     </button>
-                    <button class="btn btn-sm btn-outline-secondary ms-1" type="button" id="options-button"
-                            data-bs-toggle="collapse" data-bs-target="#options-collapse"
-                            aria-expanded="false" aria-controls="options-collapse">
-                        <i class="bi bi-gear"></i> Options
-                    </button>
                     <button type="submit" class="btn btn-sm btn-primary ms-1" id="run-query-button-top" disabled>
                         <i class="bi bi-play-fill"></i> Run
                     </button>
                 </div>
                 <p class="small text-muted mb-2" id="query-label">Compose or refine your query in SPARQL</p>
 
-                <div class="collapse mb-2" id="options-collapse">
-                    <div class="card card-body">
-                        <div class="row">
-                            <!-- First Column: Checkboxes -->
-                            <div class="col-md-6">
-                                <div class="d-flex flex-column">
-                                    <div class="form-check mb-3">
-                                        <input class="form-check-input" type="checkbox" id="strict" name="strict" checked>
-                                        <label class="form-check-label" for="strict">Strict checking of void variables</label>
-                                    </div>
-
-                                    <div class="form-check mb-3">
-                                        <input class="form-check-input" type="checkbox" id="debug" name="debug">
-                                        <label class="form-check-label" for="debug">Log debug info at the end of output</label>
-                                    </div>
-
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" id="report" name="report">
-                                        <label class="form-check-label" for="report">Generate SPARQL compilation report</label>
-                                    </div>
-                                </div>
-                            </div>
-
-                            <!-- Second Column: Inputs -->
-                            <div class="col-md-6">
-                                <div class="form-floating mb-3">
-                                    <input type="number" id="timeout" name="timeout" class="form-control"
-                                        placeholder="Enter timeout in milliseconds (optional)">
-                                    <label for="timeout">Timeout (ms)</label>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Keep the hidden default-graph-uri input -->
-                        <div class="d-none">
-                            <input type="text" id="default-graph-uri" name="default-graph-uri" class="form-control"
-                                placeholder="Enter Graph IRI (optional)">
-                        </div>
-                    </div>
+                <!-- Hidden inputs for SPARQL endpoint options (read by sparqlRequest.js) -->
+                <div class="d-none">
+                    <input type="checkbox" id="strict" name="strict" checked>
+                    <input type="checkbox" id="debug" name="debug">
+                    <input type="checkbox" id="report" name="report">
+                    <input type="number" id="timeout" name="timeout">
+                    <input type="text" id="default-graph-uri" name="default-graph-uri">
                 </div>
 
                 <div class="flex-grow-1 d-flex flex-column">

--- a/src/assets/style.css
+++ b/src/assets/style.css
@@ -653,14 +653,6 @@ main {
     margin-bottom: 0;
 }
 
-#options-collapse {
-    margin-top: 10px;
-}
-
-#options-collapse .form-check {
-    flex: 1 1 auto;
-}
-
 #query-form .mb-3.flex-grow-1 {
     flex: 1;
     min-height: 0;

--- a/src/js/DataView.js
+++ b/src/js/DataView.js
@@ -200,13 +200,11 @@ export class DataView {
           showToast('Download failed', 'Could not build a download query for the current view.', { variant: 'danger' });
           return;
         }
-        // Build the POST body from the controller's stored options
-        // rather than from the live DOM form inputs. When a shared
-        // URL loads with `?opts=...`, those options go into the
-        // controller's `_sparqlOptions` but the Options panel form
-        // is NOT repopulated. Reading from the DOM would produce a
-        // download that diverges from what produced the current
-        // graph.
+        // Build the POST body from the controller's stored options.
+        // When a shared URL loads with `?opts=...`, those options go
+        // into the controller's `_sparqlOptions`; there is no options
+        // form to read (the Options UI was removed, issue #32), so this
+        // matches exactly what produced the current graph.
         const opts = this.controller._sparqlOptions || {};
         const params = new URLSearchParams({ query, format });
         if (opts.defaultGraphUri) params.set('default-graph-uri', opts.defaultGraphUri);
@@ -244,7 +242,7 @@ export class DataView {
     } catch (error) {
       console.error('Download failed:', error);
       if (error?.name === 'AbortError') {
-        showToast('Download timed out', 'The download took too long. Try a narrower query or increase the timeout in Options.', { variant: 'danger' });
+        showToast('Download timed out', 'The download took too long. Try narrowing your query with a LIMIT or more specific filters.', { variant: 'danger' });
       } else {
         const { friendly } = classifyError(error, 'graph');
         showToast('Download failed', friendly, { variant: 'danger' });

--- a/src/js/ExplorerController.js
+++ b/src/js/ExplorerController.js
@@ -112,10 +112,9 @@ export class ExplorerController extends EventTarget {
     this.breadcrumb = [canonical];
     this.breadcrumbIndex = 0;
     // sparqlOptions are forwarded to doSPARQL so CONSTRUCT/DESCRIBE
-    // queries honour the Customize tab's Options panel (timeout,
-    // strict, debug, report, default-graph-uri). Notice-number
-    // searches pass no options because they use a canned query whose
-    // options are baked in.
+    // queries honour the fixed endpoint options from readSparqlOptions
+    // (or a shared URL's ?opts=). Notice-number searches pass no options
+    // because they use a canned query whose options are baked in.
     this._sparqlOptions = sparqlOptions;
     await this._navigated();
   }

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -362,9 +362,9 @@ export class QueryEditor {
           // need a try/catch here. If that contract ever changes
           // the unhandled rejection will surface the regression
           // immediately rather than being silently logged.
-          // Read the Options panel so CONSTRUCT/DESCRIBE queries
-          // honour timeout / strict / debug / report /
-          // default-graph-uri the same way SELECT queries do.
+          // Read the fixed endpoint options so CONSTRUCT/DESCRIBE queries
+          // send timeout / strict / debug / report / default-graph-uri
+          // the same way SELECT queries do.
           const sparqlOptions = readSparqlOptions();
           await this.explorerController.search(
             { type: 'query', query: queryText },

--- a/src/js/QueryResults.js
+++ b/src/js/QueryResults.js
@@ -231,8 +231,9 @@ export class QueryResults {
     const body = buildSparqlBody(minifiedQuery, format);
 
     try {
-      const sparqlTimeout = Number(document.getElementById('timeout')?.value) || 60_000;
-      const downloadTimeout = Math.max(sparqlTimeout, 10_000);
+      // Client-side abort ceiling for the download fetch. The user-facing
+      // server timeout option was removed (issue #32), so use a fixed 60s.
+      const downloadTimeout = 60_000;
       const abort = new AbortController();
       const timer = setTimeout(() => abort.abort(), downloadTimeout);
       const response = await fetch(this.queryEditor.sparqlEndpoint, {
@@ -258,7 +259,7 @@ export class QueryResults {
     } catch (error) {
       console.error('Download failed:', error);
       if (error?.name === 'AbortError') {
-        showToast('Download timed out', 'The download took too long. Try a narrower query or increase the timeout in Options.', { variant: 'danger' });
+        showToast('Download timed out', 'The download took too long. Try narrowing your query with a LIMIT or more specific filters.', { variant: 'danger' });
       } else {
         const { friendly } = classifyError(error, 'select');
         showToast('Download failed', friendly, { variant: 'danger' });

--- a/src/js/SearchPanel.js
+++ b/src/js/SearchPanel.js
@@ -22,7 +22,6 @@
 
 import { createPublicationNumberFacet, getLabel, getQuery } from './facets.js';
 import { getRandomPublicationNumber } from './services/randomNotice.js';
-import { hydrateSparqlOptions } from './sparqlRequest.js';
 
 const SHORT_MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -424,17 +423,6 @@ export class SearchPanel {
         // reflection, but log so a regression is visible.
         console.warn('[SearchPanel] editor reflection failed on URL load:', err);
       }
-      // If the shared URL carried SPARQL options (?opts=), hydrate
-      // the Customize tab's Options panel form so a subsequent
-      // "Run Query" from the editor reads the sender's settings
-      // instead of the recipient's local defaults. Without this,
-      // the first execution (from initFromUrlParams) is correct
-      // because the controller applies _sparqlOptions directly,
-      // but a manual re-run reads the DOM form via buildSparqlBody.
-      if (this.controller._sparqlOptions) {
-        hydrateSparqlOptions(this.controller._sparqlOptions);
-      }
-
       // URL loading is always a graph lane gesture.
       this.setActiveResultTab('graph');
       // Fresh navigation from a shared link carries explicit intent:

--- a/src/js/sparqlRequest.js
+++ b/src/js/sparqlRequest.js
@@ -13,76 +13,32 @@
  */
 // Shared SPARQL request-shape helpers.
 //
-// Three sites used to hand-build the same parameter block for the
-// Virtuoso endpoint: QueryEditor.onSubmit (POST body), QueryResults
-// .downloadAs (POST body with a caller-supplied format), and
-// QueryResults.generateUrl (GET URL for Copy endpoint URL).
+// Three sites build the same parameter block for the Virtuoso endpoint:
+// QueryEditor.onSubmit (POST body), QueryResults.downloadAs (POST body
+// with a caller-supplied format), and QueryResults.generateUrl (GET URL
+// for Copy endpoint URL). Consolidating them here keeps them honest so
+// "Copy endpoint URL" reproduces exactly what "Run Query" just ran.
 //
-// They had drifted out of sync in two places:
-//   - onSubmit / downloadAs omit `default-graph-uri` and `timeout`
-//     when the form input is blank; generateUrl always included
-//     them, so a copied URL could diverge from the query the user
-//     had just run.
-//   - onSubmit uses whatever value the timeout input has (possibly
-//     blank → omitted); generateUrl substituted 30000 when blank.
-//
-// Consolidating the three sites here keeps them honest.
+// The options they carry used to come from the Customize tab's Options
+// panel; that UI was removed (issue #32), so readSparqlOptions now returns
+// a fixed block (strict on, debug/report off, timeout/default-graph-uri
+// blank and therefore omitted).
 
 const DEFAULT_FORMAT = 'application/sparql-results+json';
 
 /**
- * Read the SPARQL options panel inputs from the DOM and return a
- * normalised object. Used by `buildSparqlBody` (for the SELECT
- * lane) and by QueryEditor's CONSTRUCT/DESCRIBE routing (which
- * passes these to ExplorerController → doSPARQL → sparqlWorker).
+ * The fixed SPARQL endpoint options every request carries. The Options UI
+ * was removed (issue #32): debug/report produced output the app never
+ * rendered, and the endpoint ignores the timeout for the values it
+ * accepted, so nothing was left worth exposing. `strict` checking stays on
+ * (the former default); `timeout` and `default-graph-uri` stay blank so the
+ * endpoint applies its own defaults (buildSparqlBody omits both). Returns a
+ * fresh object so callers can't mutate a shared constant. Used by
+ * `buildSparqlBody` (the SELECT lane) and by QueryEditor's CONSTRUCT/DESCRIBE
+ * routing (which passes these to ExplorerController → doSPARQL → sparqlWorker).
  */
 export function readSparqlOptions() {
-  const defaultGraphUri = document.getElementById('default-graph-uri')?.value || '';
-  const timeout = document.getElementById('timeout')?.value || '';
-  const strict = document.getElementById('strict')?.checked ? 'true' : 'false';
-  const debug = document.getElementById('debug')?.checked ? 'true' : 'false';
-  const report = document.getElementById('report')?.checked ? 'true' : 'false';
-  return { defaultGraphUri, timeout, strict, debug, report };
-}
-
-/**
- * Write SPARQL options into the Options panel form inputs. The
- * mirror of `readSparqlOptions` — called when a shared URL carries
- * `?opts=<JSON>` so the Customize tab's form reflects the sender's
- * settings. Without this, the first execution from the URL is
- * correct (the controller holds the options in `_sparqlOptions`),
- * but a subsequent "Run Query" from the Customize tab reads the
- * DOM form via `buildSparqlBody` and silently reverts to the
- * recipient's local defaults.
- *
- * @param {{defaultGraphUri?: string, timeout?: string,
- *          strict?: string, debug?: string, report?: string}} opts
- */
-export function hydrateSparqlOptions(opts) {
-  if (!opts || typeof opts !== 'object') return;
-
-  // Always write ALL five fields, defaulting absent keys to their
-  // empty / unchecked state. The share URL's serialiser strips
-  // empty-string values (defaultGraphUri='', timeout='') to keep
-  // the URL short, so their absence in `opts` means "the sender
-  // left this blank". If we only wrote keys that are *present*,
-  // a recipient whose form already held a non-empty timeout or
-  // default-graph-uri would keep that stale local value and a
-  // re-run from Customize would diverge from the shared request.
-  const dgu = document.getElementById('default-graph-uri');
-  if (dgu) dgu.value = opts.defaultGraphUri || '';
-
-  const timeout = document.getElementById('timeout');
-  if (timeout) timeout.value = opts.timeout || '';
-
-  const strict = document.getElementById('strict');
-  if (strict) strict.checked = opts.strict === 'true';
-
-  const debug = document.getElementById('debug');
-  if (debug) debug.checked = opts.debug === 'true';
-
-  const report = document.getElementById('report');
-  if (report) report.checked = opts.report === 'true';
+  return { defaultGraphUri: '', timeout: '', strict: 'true', debug: 'false', report: 'false' };
 }
 
 /**

--- a/src/js/sparqlWorker.js
+++ b/src/js/sparqlWorker.js
@@ -55,11 +55,10 @@ self.onmessage = async function(event) {
 
 async function _runSparqlQuery(query, endpoint, options = {}) {
   const controller = new AbortController();
-  // Use the timeout from the Options panel when the user has
-  // explicitly set one; otherwise fall back to the built-in
-  // safety net. No clamping — if the user types 120000ms they
-  // know what they are doing, and capping silently at 60s would
-  // abort their query before the endpoint has a chance to finish.
+  // Honour a timeout carried by a shared URL's ?opts= when present;
+  // otherwise fall back to the built-in safety net. No clamping — if a
+  // shared request asks for 120000ms it knows what it wants, and capping
+  // silently at 60s would abort before the endpoint has a chance to finish.
   const userTimeout = options.timeout ? Number(options.timeout) : 0;
   const timeoutMs = userTimeout > 0 ? userTimeout : SPARQL_CONSTRUCT_TIMEOUT_MS;
   const timer = setTimeout(() => controller.abort(), timeoutMs);

--- a/src/js/tours/customizeTour.js
+++ b/src/js/tours/customizeTour.js
@@ -35,15 +35,6 @@ export async function startCustomizeTour() {
       placement: 'bottom',
     },
     {
-      element: '#options-button',
-      title: 'Options',
-      content:
-        'Click to expand the options panel. Fine-tune how the endpoint executes your query: ' +
-        'set a <strong>timeout</strong>, toggle strict checking of void variables, or ask the ' +
-        'server for debug output and a compilation report.',
-      placement: 'bottom',
-    },
-    {
       element: '#run-query-button-top',
       title: 'Run your query',
       content:

--- a/test/sparqlRequest.test.js
+++ b/test/sparqlRequest.test.js
@@ -11,52 +11,46 @@
  * or implied. See the Licence for the specific language governing permissions and limitations under
  * the Licence.
  */
-// buildSparqlBody / buildSparqlUrl read the SPARQL options panel from
-// the DOM and produce the POST body / GET URL that every lane of the
-// app uses to talk to the endpoint. They absorb the three sites that
-// previously hand-built the same option block with drift between
-// them (the Copy URL path used to always include an empty
-// default-graph-uri and substitute `30000` for a blank timeout; the
-// editor submit path omits both when blank). These tests pin the
-// expected contract so a future refactor cannot silently regress the
-// "Copy URL exactly reproduces what Run Query just ran" guarantee.
+// buildSparqlBody / buildSparqlUrl produce the POST body / GET URL that
+// every lane of the app uses to talk to the endpoint. Since the Options UI
+// was removed (issue #32), readSparqlOptions returns a FIXED option block
+// instead of reading the DOM: strict on, debug/report off, timeout and
+// default-graph-uri blank (and therefore omitted). These tests pin that
+// contract and the "Copy URL exactly reproduces what Run Query ran"
+// guarantee.
 
-import { test, beforeEach } from 'node:test';
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { resetShims } from './_helpers.js';
-import { buildSparqlBody, buildSparqlUrl, hydrateSparqlOptions } from '../src/js/sparqlRequest.js';
+import { readSparqlOptions, buildSparqlBody, buildSparqlUrl } from '../src/js/sparqlRequest.js';
 
-// Stage a minimal option block in the shared DOM shim. Individual
-// tests override only the fields they need to assert on.
-function setOptions({
-  defaultGraphUri = '',
-  timeout = '',
-  strict = false,
-  debug = false,
-  report = false,
-} = {}) {
-  document.getElementById('default-graph-uri').value = defaultGraphUri;
-  document.getElementById('timeout').value = timeout;
-  document.getElementById('strict').checked = strict;
-  document.getElementById('debug').checked = debug;
-  document.getElementById('report').checked = report;
-}
+const QUERY = 'SELECT * WHERE { ?s ?p ?o }';
 
-beforeEach(() => {
-  resetShims();
-  // Re-stage fresh option elements in the cleared shim.
-  setOptions();
+// ── readSparqlOptions returns the fixed option block ──────────────
+
+test('readSparqlOptions returns the fixed endpoint options (no DOM dependency)', () => {
+  assert.deepEqual(readSparqlOptions(), {
+    defaultGraphUri: '',
+    timeout: '',
+    strict: 'true',
+    debug: 'false',
+    report: 'false',
+  });
+});
+
+test('readSparqlOptions returns a fresh object each call (no shared mutable constant)', () => {
+  const first = readSparqlOptions();
+  first.strict = 'mutated';
+  assert.equal(readSparqlOptions().strict, 'true');
 });
 
 // ── buildSparqlBody — format handling ─────────────────────────────
 
 test('buildSparqlBody defaults to sparql-results+json when no format given', () => {
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.match(body, /format=application%2Fsparql-results%2Bjson/);
+  assert.match(buildSparqlBody(QUERY), /format=application%2Fsparql-results%2Bjson/);
 });
 
 test('buildSparqlBody honours an explicit format argument', () => {
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }', 'text/csv');
+  const body = buildSparqlBody(QUERY, 'text/csv');
   assert.match(body, /format=text%2Fcsv/);
   assert.doesNotMatch(body, /format=application%2Fsparql-results/);
 });
@@ -64,161 +58,37 @@ test('buildSparqlBody honours an explicit format argument', () => {
 // ── buildSparqlBody — query encoding ──────────────────────────────
 
 test('buildSparqlBody percent-encodes the query string', () => {
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  // Spaces, braces and `?` all need encoding; `*` is safe under
-  // RFC3986 and encodeURIComponent leaves it alone, which is fine —
-  // Virtuoso accepts it either way.
-  assert.match(body, /query=SELECT%20\*%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D/);
+  // Spaces, braces and `?` all need encoding; `*` is safe under RFC3986 and
+  // encodeURIComponent leaves it alone, which Virtuoso accepts.
+  assert.match(buildSparqlBody(QUERY),
+    /query=SELECT%20\*%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D/);
 });
 
-// ── Conditional omission of default-graph-uri ─────────────────────
+// ── Fixed option block ────────────────────────────────────────────
 
-test('buildSparqlBody omits default-graph-uri when the input is blank', () => {
-  setOptions({ defaultGraphUri: '' });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
+test('buildSparqlBody always emits strict=true, debug=false, report=false', () => {
+  const body = buildSparqlBody(QUERY);
+  assert.match(body, /strict=true/);
+  assert.match(body, /debug=false/);
+  assert.match(body, /report=false/);
+});
+
+test('buildSparqlBody omits timeout and default-graph-uri (endpoint uses its own defaults)', () => {
+  const body = buildSparqlBody(QUERY);
+  assert.doesNotMatch(body, /timeout=/);
   assert.doesNotMatch(body, /default-graph-uri=/);
 });
 
-test('buildSparqlBody includes default-graph-uri when the input is set', () => {
-  setOptions({ defaultGraphUri: 'http://example.org/g' });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.match(body, /default-graph-uri=http%3A%2F%2Fexample\.org%2Fg/);
-});
-
-// ── Conditional omission of timeout ───────────────────────────────
-
-test('buildSparqlBody omits timeout when the input is blank', () => {
-  setOptions({ timeout: '' });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.doesNotMatch(body, /timeout=/);
-});
-
-test('buildSparqlBody includes timeout when the input is set', () => {
-  setOptions({ timeout: '5000' });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.match(body, /timeout=5000/);
-});
-
-test('buildSparqlBody does NOT substitute a default value for blank timeout', () => {
-  // Regression for S23: generateUrl used to emit `timeout=30000` when
-  // the input was blank, diverging from what onSubmit actually ran.
-  setOptions({ timeout: '' });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.doesNotMatch(body, /timeout=30000/);
-});
-
-// ── strict / debug / report always present as booleans ────────────
-
-test('buildSparqlBody always emits strict/debug/report as true/false', () => {
-  setOptions({ strict: true, debug: false, report: true });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.match(body, /strict=true/);
-  assert.match(body, /debug=false/);
-  assert.match(body, /report=true/);
-});
-
-test('buildSparqlBody emits strict=false when the checkbox is unchecked', () => {
-  setOptions({ strict: false });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  assert.match(body, /strict=false/);
-});
-
-// ── buildSparqlUrl prefixes the endpoint ──────────────────────────
+// ── buildSparqlUrl ────────────────────────────────────────────────
 
 test('buildSparqlUrl prefixes the endpoint with a ? separator', () => {
-  const url = buildSparqlUrl('https://example.com/sparql', 'SELECT * WHERE { ?s ?p ?o }');
+  const url = buildSparqlUrl('https://example.com/sparql', QUERY);
   assert.ok(url.startsWith('https://example.com/sparql?'));
 });
 
-test('buildSparqlUrl applies the same omission rules as buildSparqlBody', () => {
-  // Blank defaultGraphUri / timeout must NOT appear in the URL either
-  // — this is the regression test for "Copy URL diverges from what
-  // Run Query just ran".
-  setOptions({ defaultGraphUri: '', timeout: '' });
-  const url = buildSparqlUrl('https://example.com/sparql', 'SELECT * WHERE { ?s ?p ?o }');
-  assert.doesNotMatch(url, /default-graph-uri=/);
-  assert.doesNotMatch(url, /timeout=/);
-});
-
-test('buildSparqlUrl and buildSparqlBody produce the same parameter block for the same inputs', () => {
-  // Same inputs must produce the same body — the only difference is
-  // the URL wrapper prefix.
-  setOptions({ defaultGraphUri: 'http://example.org/g', timeout: '5000', strict: true });
-  const body = buildSparqlBody('SELECT * WHERE { ?s ?p ?o }');
-  const url = buildSparqlUrl('https://example.com/sparql', 'SELECT * WHERE { ?s ?p ?o }');
+test('buildSparqlUrl produces the same parameter block as buildSparqlBody', () => {
+  // "Copy endpoint URL" must exactly reproduce what Run Query just ran.
+  const body = buildSparqlBody(QUERY);
+  const url = buildSparqlUrl('https://example.com/sparql', QUERY);
   assert.equal(url, `https://example.com/sparql?${body}`);
-});
-
-// ── hydrateSparqlOptions ──────────────────────────────────────────
-
-test('hydrateSparqlOptions writes all five fields into the DOM', () => {
-  // Pre-populate the form with non-default values to simulate a
-  // recipient who has already been using the Customize tab.
-  setOptions({
-    defaultGraphUri: 'http://stale.example.org/g',
-    timeout: '99999',
-    strict: true,
-    debug: true,
-    report: true,
-  });
-
-  // Hydrate with the sender's options — including blank text fields
-  // and false booleans.
-  hydrateSparqlOptions({
-    defaultGraphUri: 'http://example.org/g',
-    timeout: '5000',
-    strict: 'true',
-    debug: 'false',
-    report: 'false',
-  });
-
-  assert.equal(document.getElementById('default-graph-uri').value, 'http://example.org/g');
-  assert.equal(document.getElementById('timeout').value, '5000');
-  assert.equal(document.getElementById('strict').checked, true);
-  assert.equal(document.getElementById('debug').checked, false);
-  assert.equal(document.getElementById('report').checked, false);
-});
-
-test('hydrateSparqlOptions clears stale form values when opts keys are absent', () => {
-  // Recipient has a pre-existing timeout and default-graph-uri.
-  setOptions({
-    defaultGraphUri: 'http://stale.example.org/g',
-    timeout: '99999',
-    strict: true,
-    debug: true,
-    report: true,
-  });
-
-  // The sender left those fields blank, so the URL serialiser
-  // stripped them. The opts object arriving from JSON.parse has
-  // no `defaultGraphUri` and no `timeout` key at all.
-  hydrateSparqlOptions({
-    strict: 'false',
-    debug: 'false',
-    report: 'false',
-  });
-
-  // Both text fields must be cleared to match the sender's intent.
-  assert.equal(document.getElementById('default-graph-uri').value, '',
-    'stale default-graph-uri must be cleared when opts omits it');
-  assert.equal(document.getElementById('timeout').value, '',
-    'stale timeout must be cleared when opts omits it');
-  // Booleans must reflect the explicit false.
-  assert.equal(document.getElementById('strict').checked, false);
-  assert.equal(document.getElementById('debug').checked, false);
-  assert.equal(document.getElementById('report').checked, false);
-});
-
-test('hydrateSparqlOptions tolerates an empty opts object gracefully', () => {
-  setOptions({ timeout: '10000', strict: true });
-
-  // An empty opts means "the sender used all defaults". Every form
-  // field must reset to its default (blank / unchecked).
-  hydrateSparqlOptions({});
-
-  assert.equal(document.getElementById('default-graph-uri').value, '');
-  assert.equal(document.getElementById('timeout').value, '');
-  assert.equal(document.getElementById('strict').checked, false);
-  assert.equal(document.getElementById('debug').checked, false);
-  assert.equal(document.getElementById('report').checked, false);
 });


### PR DESCRIPTION
The Options panel (strict, debug, report, timeout) exposed Virtuoso-specific endpoint parameters that had no reliable user-visible effect. The timeout was ignored by the server for small values, and the debug/report flags produced output not rendered by the app. Removing the UI avoids user confusion. The hidden inputs remain in the DOM with their defaults so the existing request-building code (sparqlRequest.js, shared URLs) continues to work unchanged.

Closes #32