### PR TITLE
Decouple exchange rates from app releases: data branch + InforEuro CI

### DIFF
--- a/.github/workflows/update-exchange-rates.yml
+++ b/.github/workflows/update-exchange-rates.yml
@@ -14,8 +14,6 @@ on:
   schedule:
     - cron: '0 6 3 * *'   # 06:00 UTC on the 3rd of each month (after InforEuro publishes)
   workflow_dispatch:
-  push:
-    branches: [ci/exchange-rates-update]   # TEMPORARY: pre-merge test only — REMOVE before merge
 
 permissions:
   contents: write

--- a/.github/workflows/update-exchange-rates.yml
+++ b/.github/workflows/update-exchange-rates.yml
@@ -1,0 +1,60 @@
+name: Update exchange rates
+
+# Refreshes the currency->EUR table on the `data/exchange-rates` branch from the
+# European Commission's monthly InforEuro rates. The app loads that file at runtime,
+# so updates ship without an application release (see issue #96).
+#
+# Scheduled/dispatch triggers only fire when this file is on the default branch (develop).
+# To test on a feature branch before merge, temporarily add:
+#   push:
+#     branches: [ci/exchange-rates-update]
+# and remove it before merging.
+
+on:
+  schedule:
+    - cron: '0 6 3 * *'   # 06:00 UTC on the 3rd of each month (after InforEuro publishes)
+  workflow_dispatch:
+  push:
+    branches: [ci/exchange-rates-update]   # TEMPORARY: pre-merge test only — REMOVE before merge
+
+permissions:
+  contents: write
+
+concurrency:
+  group: update-exchange-rates
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the update script (triggering ref)
+        uses: actions/checkout@v4
+        with:
+          path: app
+
+      - name: Check out the data branch
+        uses: actions/checkout@v4
+        with:
+          ref: data/exchange-rates
+          path: data
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Refresh rates from InforEuro
+        run: node app/scripts/update-exchange-rates.js data/exchange-rates.json
+
+      - name: Commit and push if changed
+        working-directory: data
+        run: |
+          if git diff --quiet -- exchange-rates.json; then
+            echo "No change — nothing to commit."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add exchange-rates.json
+          git commit -m "chore: refresh exchange rates from InforEuro"
+          git push origin HEAD:data/exchange-rates

--- a/.github/workflows/update-exchange-rates.yml
+++ b/.github/workflows/update-exchange-rates.yml
@@ -4,16 +4,19 @@ name: Update exchange rates
 # European Commission's monthly InforEuro rates. The app loads that file at runtime,
 # so updates ship without an application release (see issue #96).
 #
-# Scheduled/dispatch triggers only fire when this file is on the default branch (develop).
-# To test on a feature branch before merge, temporarily add:
-#   push:
-#     branches: [ci/exchange-rates-update]
-# and remove it before merging.
+# SECURITY: this workflow holds `contents: write` and pushes to the protected
+# `data/exchange-rates` branch, so it must only ever run trusted, reviewed code.
+# It is therefore `schedule`-only: scheduled runs always use the workflow and the
+# script as they exist on the default branch. `workflow_dispatch` is intentionally
+# omitted because a manual run can target an arbitrary ref, and GitHub would then
+# execute that ref's (unreviewed) workflow/script with the write token. To re-enable
+# manual runs safely, gate the push behind a protected Environment whose deployment
+# branch policy is limited to the default branch, and move the write credential into
+# that environment (leaving the default token read-only).
 
 on:
   schedule:
     - cron: '0 6 3 * *'   # 06:00 UTC on the 3rd of each month (after InforEuro publishes)
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -26,9 +29,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the update script (triggering ref)
+      - name: Check out the update script (default branch only)
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.repository.default_branch }}
           path: app
 
       - name: Check out the data branch

--- a/index.html
+++ b/index.html
@@ -769,9 +769,20 @@
                             <li>Type <code>epo:</code> followed by a class or property name to see ePO ontology suggestions</li>
                             <li>Type <code>a </code> after a subject to see available ePO classes</li>
                             <li>SPARQL keywords are suggested as you type</li>
+                            <li>Type <code>prefixes</code> to insert all standard PREFIX declarations at once</li>
+                            <li>Type <code>currency</code> to insert a currency-conversion snippet — an exchange-rate lookup table plus a <code>BIND</code> that converts monetary amounts to EUR</li>
                             <li>Press <b>Ctrl+Space</b> to manually trigger suggestions at any time</li>
                         </ul>
                         <p class="small text-muted">Autocomplete is based on the eProcurement Ontology (ePO) v4.2.0.</p>
+                        <p class="small text-muted">
+                            The exchange rates in the <code>currency</code> snippet are approximate and provided only to
+                            illustrate how conversion can be expressed in SPARQL. They are sourced from the European
+                            Commission's monthly
+                            <a href="https://ec.europa.eu/budg/inforeuro/" target="_blank" rel="noopener noreferrer">InforEuro</a>
+                            accounting rates and refreshed periodically. Amounts are converted at the latest available
+                            rate — not the rate at the time each notice was published — so do not rely on the result for
+                            precise or legally meaningful figures.
+                        </p>
 
                         <h4>Query Library</h4>
                         <p>

--- a/scripts/update-exchange-rates.js
+++ b/scripts/update-exchange-rates.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+
+/**
+ * Refresh exchange-rates.json (currency -> EUR) from the European Commission's
+ * official monthly InforEuro rates.
+ *
+ * InforEuro publishes `value` = units of a currency per 1 EUR (EUR -> currency).
+ * The snippet needs the inverse (currency -> EUR = 1 / value), matching the
+ * lookup table the SPARQL BIND multiplies by.
+ *
+ * The set of currencies is taken from the *existing* file, so the table stays in
+ * sync with what the dataset actually uses; a currency InforEuro doesn't list
+ * keeps its previous value (and is reported), rather than being dropped.
+ *
+ * Usage: node scripts/update-exchange-rates.js <path-to-exchange-rates.json>
+ * Exit code 0 on success (whether or not values changed); non-zero on failure.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const INFOREURO_URL = 'https://ec.europa.eu/budg/inforeuro/api/public/monthly-rates';
+const SIG_FIGS = 3;
+
+const filePath = process.argv[2];
+if (!filePath) {
+  console.error('Usage: node scripts/update-exchange-rates.js <path-to-exchange-rates.json>');
+  process.exit(2);
+}
+
+/** Round to a fixed number of significant figures (keeps the file compact and honest about precision). */
+function roundSig(value, sig = SIG_FIGS) {
+  if (value === 0 || !Number.isFinite(value)) return value;
+  const magnitude = Math.ceil(Math.log10(Math.abs(value)));
+  const factor = Math.pow(10, sig - magnitude);
+  return Math.round(value * factor) / factor;
+}
+
+async function main() {
+  const current = JSON.parse(readFileSync(filePath, 'utf8'));
+  const currencies = Object.keys(current.rates);
+
+  const res = await fetch(INFOREURO_URL, { headers: { Accept: 'application/json' } });
+  if (!res.ok) throw new Error(`InforEuro request failed: HTTP ${res.status}`);
+  const feed = await res.json();
+
+  // isoA3Code -> units per EUR
+  const perEur = new Map(feed.map(e => [e.isoA3Code, Number(e.value)]));
+
+  const nextRates = {};
+  const changed = [];
+  const missing = [];
+  for (const code of currencies) {
+    if (code === 'EUR') { nextRates.EUR = 1.0; continue; }
+    const units = perEur.get(code);
+    if (!units || units <= 0) {
+      nextRates[code] = current.rates[code]; // preserve prior value
+      missing.push(code);
+      continue;
+    }
+    const rate = roundSig(1 / units);
+    nextRates[code] = rate;
+    if (rate !== current.rates[code]) changed.push({ code, from: current.rates[code], to: rate });
+  }
+
+  const month = new Date().toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+  const next = {
+    description: `Exchange rates to EUR, sourced from the European Commission InforEuro monthly ` +
+      `accounting rates (https://ec.europa.eu/budg/inforeuro/) for ${month}. Values are the inverse ` +
+      `of the published EUR->currency rate (1 / rate). Used by the currencyconversion autocomplete ` +
+      `snippet in the SPARQL editor, for approximate value calculations only. Auto-updated by CI ` +
+      `(see OP-TED/ted-open-data#96). Keep the keys in sync with the currencies returned by the ` +
+      `sample query in the snippet; a currency not listed by InforEuro keeps its previous value.`,
+    rates: nextRates,
+  };
+
+  // Report
+  console.log(`Currencies: ${currencies.length} | refreshed from InforEuro: ${currencies.length - missing.length - 1} | changed: ${changed.length}`);
+  if (changed.length) {
+    console.log('Changed:');
+    for (const c of changed.slice(0, 100)) console.log(`  ${c.code}: ${c.from} -> ${c.to}`);
+  }
+  if (missing.length) console.log(`Not in InforEuro (kept prior value): ${missing.join(', ')}`);
+
+  const before = JSON.stringify(current);
+  const after = JSON.stringify(next);
+  if (before === after) {
+    console.log('No change — file left untouched.');
+    return;
+  }
+  writeFileSync(filePath, JSON.stringify(next, null, 2) + '\n');
+  console.log(`Wrote ${filePath}`);
+}
+
+main().catch(err => { console.error(err.message); process.exit(1); });

--- a/scripts/update-exchange-rates.js
+++ b/scripts/update-exchange-rates.js
@@ -29,34 +29,42 @@
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
 const INFOREURO_URL = 'https://ec.europa.eu/budg/inforeuro/api/public/monthly-rates';
 const SIG_FIGS = 3;
 
-const filePath = process.argv[2];
-if (!filePath) {
-  console.error('Usage: node scripts/update-exchange-rates.js <path-to-exchange-rates.json>');
-  process.exit(2);
-}
+// Currencies InforEuro legitimately does not list, so keeping their prior value is expected:
+//   BGN — Bulgaria adopted the euro in 2026; ANG — retired for the Caribbean guilder (XCG);
+//   USN — an ISO 4217 fund code, never a circulating currency.
+// Anything else going missing means a partial/bad feed, so we fail instead of silently
+// shipping stale numbers under a fresh date.
+const ALLOWED_MISSING = new Set(['BGN', 'ANG', 'USN']);
 
 /** Round to a fixed number of significant figures (keeps the file compact and honest about precision). */
-function roundSig(value, sig = SIG_FIGS) {
+export function roundSig(value, sig = SIG_FIGS) {
   if (value === 0 || !Number.isFinite(value)) return value;
   const magnitude = Math.ceil(Math.log10(Math.abs(value)));
   const factor = Math.pow(10, sig - magnitude);
   return Math.round(value * factor) / factor;
 }
 
-async function main() {
-  const current = JSON.parse(readFileSync(filePath, 'utf8'));
+/**
+ * Pure transform: given the current file contents and a raw InforEuro feed, compute the next
+ * currency -> EUR rates. Throws on an empty or partial feed so CI fails loudly rather than
+ * republishing stale numbers under a fresh date.
+ *
+ * @param {{ rates: Object<string, number> }} current - parsed exchange-rates.json
+ * @param {Array<{ isoA3Code: string, value: number }>} feed - InforEuro monthly-rates response
+ * @returns {{ nextRates: Object<string, number>, changed: Array<{code:string,from:number,to:number}>, missing: string[] }}
+ */
+export function computeRates(current, feed) {
+  if (!Array.isArray(feed) || feed.length === 0) {
+    throw new Error('InforEuro returned an empty or malformed feed — refusing to publish (would relabel stale rates as current).');
+  }
+
   const currencies = Object.keys(current.rates);
-
-  const res = await fetch(INFOREURO_URL, { headers: { Accept: 'application/json' } });
-  if (!res.ok) throw new Error(`InforEuro request failed: HTTP ${res.status}`);
-  const feed = await res.json();
-
-  // isoA3Code -> units per EUR
-  const perEur = new Map(feed.map(e => [e.isoA3Code, Number(e.value)]));
+  const perEur = new Map(feed.map(e => [e.isoA3Code, Number(e.value)])); // isoA3Code -> units per EUR
 
   const nextRates = {};
   const changed = [];
@@ -74,8 +82,20 @@ async function main() {
     if (rate !== current.rates[code]) changed.push({ code, from: current.rates[code], to: rate });
   }
 
-  const month = new Date().toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' });
-  const next = {
+  const unexpectedMissing = missing.filter(code => !ALLOWED_MISSING.has(code));
+  if (unexpectedMissing.length) {
+    throw new Error(
+      `InforEuro feed is missing ${unexpectedMissing.length} currency(ies) not on the known list: ` +
+      `${unexpectedMissing.join(', ')}. Refusing to publish a partial refresh; ` +
+      `update ALLOWED_MISSING or the currency set if this is a permanent change.`);
+  }
+
+  return { nextRates, changed, missing };
+}
+
+/** Assemble the file body (description carrying the month label + the rates). */
+export function buildFile(nextRates, month) {
+  return {
     description: `Exchange rates to EUR, sourced from the European Commission InforEuro monthly ` +
       `accounting rates (https://ec.europa.eu/budg/inforeuro/) for ${month}. Values are the inverse ` +
       `of the published EUR->currency rate (1 / rate). Used by the currencyconversion autocomplete ` +
@@ -84,23 +104,45 @@ async function main() {
       `sample query in the snippet; a currency not listed by InforEuro keeps its previous value.`,
     rates: nextRates,
   };
+}
 
-  // Report
-  console.log(`Currencies: ${currencies.length} | refreshed from InforEuro: ${currencies.length - missing.length - 1} | changed: ${changed.length}`);
+async function main() {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: node scripts/update-exchange-rates.js <path-to-exchange-rates.json>');
+    process.exit(2);
+  }
+
+  const current = JSON.parse(readFileSync(filePath, 'utf8'));
+
+  const res = await fetch(INFOREURO_URL, { headers: { Accept: 'application/json' } });
+  if (!res.ok) throw new Error(`InforEuro request failed: HTTP ${res.status}`);
+  const feed = await res.json();
+
+  const { nextRates, changed, missing } = computeRates(current, feed);
+
+  const total = Object.keys(current.rates).length;
+  console.log(`Currencies: ${total} | refreshed from InforEuro: ${total - missing.length - 1} | changed: ${changed.length}`);
   if (changed.length) {
     console.log('Changed:');
     for (const c of changed.slice(0, 100)) console.log(`  ${c.code}: ${c.from} -> ${c.to}`);
   }
   if (missing.length) console.log(`Not in InforEuro (kept prior value): ${missing.join(', ')}`);
 
-  const before = JSON.stringify(current);
-  const after = JSON.stringify(next);
-  if (before === after) {
-    console.log('No change — file left untouched.');
+  // Key the write on actual rate movements, not the file's month label. The month lives only in
+  // the description, so comparing the whole JSON would commit a metadata-only change every month
+  // even when no rate moved — and, worse, would relabel unchanged (possibly stale) rates as current.
+  if (changed.length === 0) {
+    console.log('No rate changes — file left untouched.');
     return;
   }
-  writeFileSync(filePath, JSON.stringify(next, null, 2) + '\n');
-  console.log(`Wrote ${filePath}`);
+
+  const month = new Date().toLocaleString('en-GB', { month: 'long', year: 'numeric', timeZone: 'UTC' });
+  writeFileSync(filePath, JSON.stringify(buildFile(nextRates, month), null, 2) + '\n');
+  console.log(`Wrote ${filePath} — ${changed.length} rate change(s), labelled ${month}.`);
 }
 
-main().catch(err => { console.error(err.message); process.exit(1); });
+// Run only when invoked directly, so tests can import the pure helpers without triggering a fetch.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch(err => { console.error(err.message); process.exit(1); });
+}

--- a/src/js/epoCompletion.js
+++ b/src/js/epoCompletion.js
@@ -42,11 +42,13 @@ async function ensureLoaded() {
 
 // Exchange rates are served from the protected `data/exchange-rates` branch so they can be
 // refreshed by CI without an app release (see issue #96). The `refs/heads/` form is required
-// because the branch name contains a slash. If the remote is unreachable we fall back to the
-// copy bundled with the app, which is approximate but keeps the snippet working.
+// because the branch name contains a slash. If the remote is unreachable — or slow: the fetch
+// is time-boxed so a hanging request still fails over promptly — we fall back to the copy
+// bundled with the app, which is approximate but keeps the snippet working.
 const REMOTE_EXCHANGE_RATES_URL =
   'https://raw.githubusercontent.com/OP-TED/ted-open-data/refs/heads/data/exchange-rates/exchange-rates.json';
 const LOCAL_EXCHANGE_RATES_URL = 'src/assets/exchange-rates.json';
+const REMOTE_EXCHANGE_RATES_TIMEOUT_MS = 4000;
 
 /**
  * Load exchange rates, preferring the CI-maintained data branch and falling back to the
@@ -55,7 +57,7 @@ const LOCAL_EXCHANGE_RATES_URL = 'src/assets/exchange-rates.json';
 async function ensureExchangeRatesLoaded() {
   if (exchangeRatesData) return;
   if (exchangeRatesPromise) return exchangeRatesPromise;
-  exchangeRatesPromise = fetch(REMOTE_EXCHANGE_RATES_URL)
+  exchangeRatesPromise = fetch(REMOTE_EXCHANGE_RATES_URL, { signal: AbortSignal.timeout(REMOTE_EXCHANGE_RATES_TIMEOUT_MS) })
     .then(r => {
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       return r.json();

--- a/src/js/epoCompletion.js
+++ b/src/js/epoCompletion.js
@@ -57,7 +57,13 @@ const REMOTE_EXCHANGE_RATES_TIMEOUT_MS = 4000;
 async function ensureExchangeRatesLoaded() {
   if (exchangeRatesData) return;
   if (exchangeRatesPromise) return exchangeRatesPromise;
-  exchangeRatesPromise = fetch(REMOTE_EXCHANGE_RATES_URL, { signal: AbortSignal.timeout(REMOTE_EXCHANGE_RATES_TIMEOUT_MS) })
+  // AbortController + setTimeout (as in NoticeView) rather than AbortSignal.timeout(): the latter
+  // would be evaluated synchronously in the fetch arguments, so on a runtime that lacks it the
+  // TypeError would throw before the .catch is attached — skipping the fallback and leaving an
+  // unhandled rejection. AbortController exists wherever fetch does.
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REMOTE_EXCHANGE_RATES_TIMEOUT_MS);
+  exchangeRatesPromise = fetch(REMOTE_EXCHANGE_RATES_URL, { signal: controller.signal })
     .then(r => {
       if (!r.ok) throw new Error(`HTTP ${r.status}`);
       return r.json();
@@ -70,7 +76,8 @@ async function ensureExchangeRatesLoaded() {
     .catch(err => {
       console.error('Failed to load exchange rates:', err);
       exchangeRatesPromise = null;
-    });
+    })
+    .finally(() => clearTimeout(timer));
   return exchangeRatesPromise;
 }
 

--- a/src/js/epoCompletion.js
+++ b/src/js/epoCompletion.js
@@ -40,14 +40,30 @@ async function ensureLoaded() {
   return loadingPromise;
 }
 
+// Exchange rates are served from the protected `data/exchange-rates` branch so they can be
+// refreshed by CI without an app release (see issue #96). The `refs/heads/` form is required
+// because the branch name contains a slash. If the remote is unreachable we fall back to the
+// copy bundled with the app, which is approximate but keeps the snippet working.
+const REMOTE_EXCHANGE_RATES_URL =
+  'https://raw.githubusercontent.com/OP-TED/ted-open-data/refs/heads/data/exchange-rates/exchange-rates.json';
+const LOCAL_EXCHANGE_RATES_URL = 'src/assets/exchange-rates.json';
+
 /**
- * Load exchange rates from the JSON file. Called once, cached thereafter.
+ * Load exchange rates, preferring the CI-maintained data branch and falling back to the
+ * bundled copy. Called once, cached thereafter.
  */
 async function ensureExchangeRatesLoaded() {
   if (exchangeRatesData) return;
   if (exchangeRatesPromise) return exchangeRatesPromise;
-  exchangeRatesPromise = fetch('src/assets/exchange-rates.json')
-    .then(r => r.json())
+  exchangeRatesPromise = fetch(REMOTE_EXCHANGE_RATES_URL)
+    .then(r => {
+      if (!r.ok) throw new Error(`HTTP ${r.status}`);
+      return r.json();
+    })
+    .catch(err => {
+      console.warn('Remote exchange rates unavailable, using bundled copy:', err);
+      return fetch(LOCAL_EXCHANGE_RATES_URL).then(r => r.json());
+    })
     .then(data => { exchangeRatesData = data; })
     .catch(err => {
       console.error('Failed to load exchange rates:', err);

--- a/test/updateExchangeRates.test.js
+++ b/test/updateExchangeRates.test.js
@@ -1,0 +1,37 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { computeRates, roundSig } from '../scripts/update-exchange-rates.js';
+
+// Minimal stand-in for exchange-rates.json. BGN is in ALLOWED_MISSING; USD/GBP are not.
+const current = { rates: { EUR: 1.0, USD: 0.92, GBP: 1.17, BGN: 0.511 } };
+const entry = (isoA3Code, value) => ({ isoA3Code, value });
+
+test('roundSig keeps 3 significant figures', () => {
+  assert.equal(roundSig(1 / 655.957), 0.00152); // XAF peg
+  assert.equal(roundSig(1.0536), 1.05);
+  assert.equal(roundSig(0), 0);
+});
+
+test('throws on an empty feed instead of relabelling stale rates as current', () => {
+  assert.throws(() => computeRates(current, []), /empty or malformed/);
+});
+
+test('throws on a partial feed when a required currency is absent', () => {
+  // Only USD present: GBP (required) and BGN (allowed) are absent -> must fail on GBP.
+  assert.throws(() => computeRates(current, [entry('USD', 1 / 0.9)]), /missing .*not on the known list/);
+});
+
+test('keeps the prior value for an allowed-missing currency without failing', () => {
+  const { nextRates, missing } = computeRates(current, [entry('USD', 1 / 0.9), entry('GBP', 1 / 1.2)]);
+  assert.deepEqual(missing, ['BGN']);
+  assert.equal(nextRates.BGN, 0.511); // preserved, not dropped
+  assert.equal(nextRates.EUR, 1.0);
+});
+
+test('reports only real rate movements (after rounding), not noise', () => {
+  // USD inverts back to 0.92 (unchanged after rounding); GBP moves to 1.1.
+  const { changed } = computeRates(current, [entry('USD', 1 / 0.92), entry('GBP', 1 / 1.10)]);
+  const codes = changed.map(c => c.code);
+  assert.ok(codes.includes('GBP'), 'GBP should be reported as changed');
+  assert.ok(!codes.includes('USD'), 'USD rounds back to its prior value and must not be reported');
+});


### PR DESCRIPTION
Follow-up to the interim currency snippet (#94). Closes #96.

## Problem
The `currency → EUR` rates shipped in `src/assets/exchange-rates.json` and are served straight from the deployed tree (GitHub Pages), so refreshing them required a full app release.

## Change
Rates now live on the protected orphan branch `data/exchange-rates` and are refreshed by CI — **no app release needed**.

- **App (`src/js/epoCompletion.js`)** — `ensureExchangeRatesLoaded` fetches the rates from the data branch's raw URL and **falls back to the bundled `src/assets/exchange-rates.json`** if the remote fails, errors, or is slow. The fetch is time-boxed (4s, via `AbortController`) so a hanging host still fails over. The URL uses the `refs/heads/` form (required because the branch name contains a slash).
- **CI (`.github/workflows/update-exchange-rates.yml` + `scripts/update-exchange-rates.js`)** — **schedule-only** monthly job that pulls the European Commission's [InforEuro](https://ec.europa.eu/budg/inforeuro/) monthly accounting rates, inverts them to `currency → EUR`, filters to the currencies already in the file, and commits to `data/exchange-rates` **only when a rate actually changes**.
- **Help tab (`index.html`)** — documents the `currency` snippet and its rate source (InforEuro), with an approximate-use caveat.
- **Tests (`test/updateExchangeRates.test.js`)** — cover the empty-feed, partial-feed, allowed-missing, and change-detection paths against the extracted pure `computeRates()`.

## Design & security notes
- **The bundled `src/assets/exchange-rates.json` is intentionally left as-is** — it's the runtime fallback. Auto-updating it would mean committing to `develop` (a release), which defeats the purpose. It's allowed to drift; the help text labels the rates approximate.
- **The workflow is `schedule`-only on purpose.** It holds `contents: write` and pushes to the protected data branch, so it must only ever run reviewed, default-branch code. `workflow_dispatch` is omitted because a manual run can target an arbitrary ref, and GitHub would then execute that ref's unreviewed workflow/script with the write token. The script checkout is pinned to the default branch. (To re-enable manual runs safely later: gate the push behind a protected Environment limited to the default branch.)
- **The updater fails loudly on a bad feed** — an empty/malformed feed or any missing currency outside the known set (`BGN`, `ANG`, `USN`) throws instead of republishing stale numbers under a fresh date.
- **Why InforEuro over ECB:** it's an official EC source and covers every currency in the dataset, including the ~20 exotics (ALL, MKD, RSD, TND, XAF, XOF…) the ECB reference rates don't publish.
- No CSP concern: prod is GitHub Pages and the Query Library already fetches from `raw.githubusercontent.com` at runtime.

## Verification
- End-to-end proven during development (via a temporary, since-removed push trigger): the workflow ran, `github-actions[bot]` committed refreshed rates to the protected branch, and the raw URL served current InforEuro values — confirming the `data/**` ruleset allows the bot's fast-forward commits while blocking deletion/force-push.
- 266 tests pass; CodeMirror build passes; syntax/diff checks clean.

Phase A (orphan branch + protection ruleset) is already in place; this PR delivers the CI and the app-side switch. Addresses two rounds of review (workflow-dispatch bypass, partial/stale-feed handling, fetch timeout + runtime-safe fallback).
