### PR TITLE
Render web URLs as clickable links in SELECT results table

### DIFF
--- a/src/js/QueryResults.js
+++ b/src/js/QueryResults.js
@@ -19,6 +19,14 @@ import { buildSparqlBody, buildSparqlUrl } from './sparqlRequest.js';
 import { showToast } from './utils/toast.js';
 import { ChartView } from './ChartView.js';
 
+// Domains that host actual navigable web pages in TED query results.
+// An allowlist is safer than a blocklist: it stays correct as new
+// data namespaces are added to the triplestore without needing updates here.
+// Only URIs whose hostname is in this set are rendered as clickable links.
+const NAVIGABLE_DOMAINS = new Set([
+  'ted.europa.eu',
+]);
+
 /**
  * Class representing the Query Results.
  * This class is responsible for displaying the results of SPARQL queries and handling related actions.
@@ -137,7 +145,8 @@ export class QueryResults {
         tr.className = index % 2 === 1 ? 'even' : '';
         headers.forEach((header) => {
           const td = tr.insertCell();
-          td.textContent = row[header]?.value || "";
+          const binding = row[header];
+          td.appendChild(this._renderCell(binding));
         });
       });
 
@@ -148,6 +157,51 @@ export class QueryResults {
       this.resultsDiv.textContent = "No results found.";
       this.setToolbarVisible(false);
       this.chartView.destroy();
+    }
+  }
+
+  /**
+   * Render a single SPARQL result binding as a DOM node.
+   * URI bindings that look like navigable web URLs (http/https pointing
+   * to a known web domain) are rendered as clickable links opening in a
+   * new tab. Everything else is plain text.
+   *
+   * Security is provided entirely by _isWebUrl: it uses new URL() to parse
+   * the value and checks the hostname against an allowlist of known
+   * navigable domains. Any dangerous scheme (javascript:, data:, etc.)
+   * either fails to parse or returns a hostname that isn't in the allowlist.
+   *
+   * @param {{ type: string, value: string }|undefined} binding
+   * @returns {Node}
+   */
+  _renderCell(binding) {
+    const value = binding?.value || '';
+    if (binding?.type === 'uri' && QueryResults._isWebUrl(value)) {
+      const a = document.createElement('a');
+      a.href = value;
+      a.textContent = value;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      return a;
+    }
+    return document.createTextNode(value);
+  }
+
+  /**
+   * Returns true only for http/https URIs whose hostname is in the
+   * NAVIGABLE_DOMAINS allowlist — i.e. URIs that point to real web pages
+   * rather than ontology terms or RDF data resources.
+   *
+   * @param {string} value
+   * @returns {boolean}
+   */
+  static _isWebUrl(value) {
+    try {
+      const { protocol, hostname } = new URL(value);
+      if (protocol !== 'http:' && protocol !== 'https:') return false;
+      return NAVIGABLE_DOMAINS.has(hostname);
+    } catch {
+      return false;
     }
   }
 

--- a/test/_helpers.js
+++ b/test/_helpers.js
@@ -93,6 +93,8 @@ if (typeof globalThis.window === 'undefined') {
 class StubElement {
   constructor(id) {
     this.id = id;
+    this.nodeType = 1; // Node.ELEMENT_NODE — text nodes use 3 (see createTextNode)
+    this.tagName = undefined;
     this.style = {};
     this.dataset = {};
     this.classList = new StubClassList();
@@ -149,8 +151,10 @@ if (typeof globalThis.document === 'undefined') {
       if (!_stubElements.has(id)) _stubElements.set(id, new StubElement(id));
       return _stubElements.get(id);
     },
-    createElement(_tag) {
-      return new StubElement(null);
+    createElement(tag) {
+      const el = new StubElement(null);
+      el.tagName = tag ? String(tag).toUpperCase() : undefined;
+      return el;
     },
     createTextNode(text) {
       // A text node is a leaf with a textContent and a nodeType. The

--- a/test/queryResults.test.js
+++ b/test/queryResults.test.js
@@ -86,8 +86,9 @@ test('_renderCell renders a web URL as an anchor element', () => {
   const qr = makeQueryResults();
   const binding = { type: 'uri', value: 'https://ted.europa.eu/en/notice/-/detail/123-2024' };
   const node = qr._renderCell(binding);
-  // Should be an element (not a text node with nodeType 3)
-  assert.notEqual(node.nodeType, 3, 'should be an element, not a text node');
+  // Should be an anchor element (nodeType 1), not a text node (nodeType 3)
+  assert.equal(node.nodeType, 1, 'should be an element node');
+  assert.equal(node.tagName, 'A', 'should be an anchor element');
   assert.equal(node.href, binding.value);
   assert.equal(node.target, '_blank');
   assert.equal(node.rel, 'noopener noreferrer');

--- a/test/queryResults.test.js
+++ b/test/queryResults.test.js
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 European Union
+ *
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European
+ * Commission – subsequent versions of the EUPL (the "Licence"); You may not use this work except in
+ * compliance with the Licence. You may obtain a copy of the Licence at:
+ * https://joinup.ec.europa.eu/software/page/eupl
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence
+ * is distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the Licence for the specific language governing permissions and limitations under
+ * the Licence.
+ */
+// QueryResults._isWebUrl and _renderCell tests.
+//
+// _isWebUrl determines which URI bindings in the results table get
+// rendered as clickable links vs. plain text. Getting this wrong either
+// breaks TED links (false negative) or makes ontology URIs clickable
+// (false positive). Both are user-visible regressions.
+//
+// _renderCell is the rendering function that uses _isWebUrl.
+// Tests cover the three cases: navigable web URL, ontology URI, literal.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import './_helpers.js';
+import { QueryResults } from '../src/js/QueryResults.js';
+
+// ── _isWebUrl ──────────────────────────────────────────────────────
+
+test('_isWebUrl accepts a TED notice URL (https://ted.europa.eu)', () => {
+  assert.equal(QueryResults._isWebUrl('https://ted.europa.eu/en/notice/-/detail/123-2024'), true);
+});
+
+test('_isWebUrl accepts an XML source URL (https://ted.europa.eu)', () => {
+  assert.equal(QueryResults._isWebUrl('https://ted.europa.eu/en/notice/123-2024/xml'), true);
+});
+
+test('_isWebUrl rejects an ePO ontology URI (data.europa.eu)', () => {
+  assert.equal(QueryResults._isWebUrl('http://data.europa.eu/a4g/ontology#Notice'), false);
+});
+
+test('_isWebUrl rejects an ePO resource URI (data.europa.eu)', () => {
+  assert.equal(QueryResults._isWebUrl('http://data.europa.eu/a4g/resource/id_xxx_Notice'), false);
+});
+
+test('_isWebUrl rejects a publications.europa.eu authority URI', () => {
+  assert.equal(QueryResults._isWebUrl('http://publications.europa.eu/resource/authority/notice-type/can-standard'), false);
+});
+
+test('_isWebUrl rejects a W3C namespace URI', () => {
+  assert.equal(QueryResults._isWebUrl('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'), false);
+});
+
+test('_isWebUrl rejects a purl.org URI', () => {
+  assert.equal(QueryResults._isWebUrl('http://purl.org/dc/elements/1.1/identifier'), false);
+});
+
+test('_isWebUrl rejects a non-http URI', () => {
+  assert.equal(QueryResults._isWebUrl('urn:isbn:978-3-16-148410-0'), false);
+});
+
+test('_isWebUrl rejects empty string', () => {
+  assert.equal(QueryResults._isWebUrl(''), false);
+});
+
+test('_isWebUrl rejects a domain not in the allowlist', () => {
+  // An http URI on an unknown domain is not navigable — the allowlist
+  // ensures only explicitly approved domains produce clickable links.
+  assert.equal(QueryResults._isWebUrl('https://example.com/some/path'), false);
+});
+
+// ── _renderCell ────────────────────────────────────────────────────
+
+// Build a minimal QueryResults instance using Object.create to skip
+// the constructor. The constructor requires Bootstrap (new bootstrap.Tab)
+// and ChartView (new ChartView + ECharts) which are not available in
+// Node.js. Object.create(QueryResults.prototype) gives us an object with
+// all the class methods (including _renderCell) without running the
+// constructor.
+function makeQueryResults() {
+  return Object.create(QueryResults.prototype);
+}
+
+test('_renderCell renders a web URL as an anchor element', () => {
+  const qr = makeQueryResults();
+  const binding = { type: 'uri', value: 'https://ted.europa.eu/en/notice/-/detail/123-2024' };
+  const node = qr._renderCell(binding);
+  // Should be an element (not a text node with nodeType 3)
+  assert.notEqual(node.nodeType, 3, 'should be an element, not a text node');
+  assert.equal(node.href, binding.value);
+  assert.equal(node.target, '_blank');
+  assert.equal(node.rel, 'noopener noreferrer');
+  assert.equal(node.textContent, binding.value);
+});
+
+test('_renderCell renders an ontology URI as plain text', () => {
+  const qr = makeQueryResults();
+  const binding = { type: 'uri', value: 'http://data.europa.eu/a4g/ontology#Notice' };
+  const node = qr._renderCell(binding);
+  assert.equal(node.nodeType, 3);
+  assert.equal(node.textContent || node.nodeValue, binding.value);
+});
+
+test('_renderCell renders a literal as plain text', () => {
+  const qr = makeQueryResults();
+  const binding = { type: 'literal', value: '2024-11-04' };
+  const node = qr._renderCell(binding);
+  assert.equal(node.nodeType, 3);
+  assert.equal(node.textContent || node.nodeValue, '2024-11-04');
+});
+
+test('_renderCell renders undefined binding as empty text', () => {
+  const qr = makeQueryResults();
+  const node = qr._renderCell(undefined);
+  assert.equal(node.nodeType, 3);
+  assert.equal(node.textContent || node.nodeValue, '');
+});
+
+test('_renderCell does not make a javascript: URI clickable', () => {
+  const qr = makeQueryResults();
+  const binding = { type: 'uri', value: 'javascript:alert(1)' };
+  const node = qr._renderCell(binding);
+  // _isWebUrl parses the URI with new URL() and checks the hostname
+  // against NAVIGABLE_DOMAINS. javascript: URIs don't have an http/https
+  // protocol so they never match — rendered as plain text.
+  assert.equal(node.nodeType, 3);
+});


### PR DESCRIPTION
URI bindings whose hostname is in a navigable domains allowlist (currently ted.europa.eu) are rendered as anchor elements opening in a new tab. All other URIs (ontology terms, RDF resources, vocabulary namespaces) remain plain text. Security is provided by _isWebUrl which parses the URI with new URL() and checks protocol + hostname against the allowlist; dangerous schemes (javascript:, data:) either fail parsing or never match.

Adds _renderCell and static _isWebUrl to QueryResults, a NAVIGABLE_DOMAINS module-level constant, and 15 unit tests covering acceptance, rejection, and XSS protection.

To verify: run the query Named graphs published on a specified period under Advanced queries in the Explore tab. The accessUrl and xmlSource columns should be clickable links pointing to ted.europa.eu.

Closes #54
