### PR TITLE
fix: use rdf:type for tree badge labels instead of URI segment 

### DIFF
--- a/src/js/TreeRenderer.js
+++ b/src/js/TreeRenderer.js
@@ -328,7 +328,21 @@ export class TreeRenderer {
       header.appendChild(document.createTextNode(' → '));
     }
 
-    header.appendChild(renderSubjectBadge(subjectValue));
+    const badge = renderSubjectBadge(subjectValue);
+    // Use the actual rdf:type local name for the badge type instead of the
+    // URI segment, which may be a mapping-specific class name (e.g.
+    // "SettledContract" instead of the ontology class "Contract").
+    const types = predicates.get(RDF_TYPE) || [];
+    if (types.length > 0 && badge.querySelector('.split-badge-type')) {
+      // Prefer the type with the shortest local name — picks the most
+      // general/canonical class (e.g. "Contract" over "PurchaseContract").
+      const typeUri = types
+        .map(t => t.value)
+        .sort((a, b) => a.split(/[#/]/).pop().length - b.split(/[#/]/).pop().length)[0];
+      const typeLocalName = typeUri.split(/[#/]/).pop();
+      badge.querySelector('.split-badge-type').textContent = typeLocalName;
+    }
+    header.appendChild(badge);
 
     // Add info icon for root-level cards (no incoming predicate)
     if (!incomingPredicate) {


### PR DESCRIPTION
Resolves https://github.com/OP-TED/ted-open-data/issues/74 .

The tree view badges previously displayed the class name extracted from the resource URI (e.g. "SettledContract"), which is a mapping-specific name that does not match the ePO ontology terminology.

Now the badge type text is taken from the subject's rdf:type triple, which declares the actual ontology class (e.g. "Contract"). The type data is already in the loaded triples — no extra network call needed.

For resources with multiple rdf:type values, the type with the shortest local name is preferred to ensure the most general/canonical class is shown consistently regardless of triple order from the endpoint.

**Key changes:**
- SettledContract → Contract
- Organization → Business
- LotPurpose → Purpose
- MonetaryValueLot/Procedure/etc → MonetaryValue
- ProcurementProjectContractTerm → ContractTerm

Terms whose URI segment already matches rdf:type (Lot, Procedure, Buyer, Tender, etc.) are unaffected.

Note: Only resources with split badges (those with identifiers like CON-0001, LOT-0008) are affected. The root Notice badge goes through a different rendering path (non-split) and was already correct.