### PR TITLE
feat: replace Copy endpoint URL with Copy Query dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
                                 When you find what you need, take it home. Look for the
                                 <strong style="white-space: nowrap;"><i class="bi bi-download"></i>&nbsp;Download</strong>
                                 button to get the results in the format that fits your work. Look for the
-                                <strong style="white-space: nowrap;"><i class="bi bi-rocket-takeoff"></i>&nbsp;Copy endpoint URL</strong>
+                                <strong style="white-space: nowrap;"><i class="bi bi-clipboard"></i>&nbsp;Copy Query</strong>
                                 button to call the same query from your own application and keep it up
                                 to date with live data all the time.
                             </p>
@@ -469,7 +469,17 @@
                     <p class="small text-muted mb-0" id="query-execution-time" style="display: none;">Execution time: <span id="query-execution-time-value"></span></p>
                 </div>
                 <div class="results-toolbar-actions">
-                    <button type="button" id="copy-url-button" class="btn btn-sm btn-outline-secondary me-2"><i class="bi bi-rocket-takeoff"></i> Copy endpoint URL</button>
+                    <div class="dropdown d-inline-block me-2">
+                        <button id="copy-url-button" class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button"
+                                data-bs-toggle="dropdown" aria-expanded="false">
+                            <i class="bi bi-clipboard"></i> Copy Query
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="copy-url-button">
+                            <li><a class="dropdown-item" href="#" data-share-type="query-link"><i class="bi bi-link-45deg me-2"></i>Query link</a></li>
+                            <li><a class="dropdown-item" href="#" data-share-type="sparql-query"><i class="bi bi-code-slash me-2"></i>SPARQL query</a></li>
+                            <li><a class="dropdown-item" href="#" data-share-type="curl-command"><i class="bi bi-terminal me-2"></i>cURL command</a></li>
+                        </ul>
+                    </div>
                     <div class="dropdown d-inline-block">
                         <button id="download-as-button" class="btn btn-sm btn-outline-primary dropdown-toggle" type="button"
                                 data-bs-toggle="dropdown" aria-expanded="false">
@@ -728,6 +738,7 @@
                                             <li><b>Copy property path:</b> Hover any nested node in the tree view to reveal a clipboard icon. Clicking it copies a ready-to-use SPARQL triple pattern snippet.</li>
                                             <li><b>Ontology-aligned badge labels:</b> Tree view badges now show ePO ontology class names (e.g. "Contract") instead of mapping-specific names (e.g. "SettledContract").</li>
                                             <li><b>Date validation:</b> Invalid dates in the SPARQL editor are flagged with red underline and the Run button is disabled. The form validates date ranges (start ≤ end).</li>
+                                            <li><b>Copy Query menu:</b> The results toolbar now offers a dropdown to copy the query as a link (for Excel/Power BI), raw SPARQL text, or a cURL command.</li>
                                         </ul>
                                     </div>
                                 </div>

--- a/src/js/QueryEditor.js
+++ b/src/js/QueryEditor.js
@@ -551,16 +551,16 @@ export class QueryEditor {
     this.resultsErrorMessage.textContent = friendly;
     if (action?.kind === 'copy-select-url') {
       // Append a space + inline link + period to the friendly
-      // sentence. Clicking the link calls the existing Copy URL
-      // handler on QueryResults so the user gets the same toast
-      // and the same JSON-format URL we offer from the toolbar.
+      // sentence. Clicking the link calls the Copy Query handler
+      // on QueryResults so the user gets the same toast and the
+      // same JSON-format URL we offer from the toolbar.
       this.resultsErrorMessage.appendChild(document.createTextNode(' You can still '));
       const link = document.createElement('a');
       link.href = '#';
       link.textContent = action.label;
       link.addEventListener('click', (e) => {
         e.preventDefault();
-        this.queryResults?.onCopyUrl();
+        this.queryResults?.onShare('query-link');
       });
       this.resultsErrorMessage.appendChild(link);
       this.resultsErrorMessage.appendChild(document.createTextNode(' to use the query from a tool that can handle long-running requests.'));

--- a/src/js/QueryResults.js
+++ b/src/js/QueryResults.js
@@ -41,7 +41,6 @@ export class QueryResults {
     this.queryEditor = queryEditor;
     this.originalSparqlEndpoint = originalSparqlEndpoint;
     this.resultsDiv = document.getElementById("results");
-    this.copyUrlButton = document.getElementById('copy-url-button');
     this.copyUrlAlert = document.getElementById('copy-url-alert');
     this.queryResultsTab = new bootstrap.Tab(document.getElementById('query-results-tab'));
     this.chartView = new ChartView();
@@ -51,13 +50,20 @@ export class QueryResults {
 
   /**
    * Initialize event listeners.
-   * Wires the Copy URL button and every dropdown item in the
+   * Wires the Copy Query dropdown items and every dropdown item in the
    * "Download as…" menu. Each download item carries a
    * data-download-format attribute with the MIME type to request.
    */
   initEventListeners() {
-    this.copyUrlButton.addEventListener('click', this.onCopyUrl.bind(this));
+    // Copy Query dropdown items
+    document.querySelectorAll('#copy-url-alert [data-share-type]').forEach(item => {
+      item.addEventListener('click', (e) => {
+        e.preventDefault();
+        this.onShare(item.dataset.shareType);
+      });
+    });
 
+    // Download as… dropdown items
     document.querySelectorAll('#copy-url-alert [data-download-format]').forEach(item => {
       item.addEventListener('click', (e) => {
         e.preventDefault();
@@ -85,7 +91,7 @@ export class QueryResults {
 
   /**
    * Show or hide the slim results toolbar (the strip above the table
-   * that holds the hint, the Copy endpoint URL button and the
+   * that holds the hint, the Copy Query dropdown and the
    * Download as… menu). Centralised here so every lane that needs to
    * toggle it (displayJsonResults, displayTextResults, the SELECT
    * submit paths in QueryEditor) goes through one place.
@@ -206,6 +212,24 @@ export class QueryResults {
   }
 
   /**
+   * Build a ready-to-paste cURL command that reproduces a SPARQL POST
+   * request. The body is a URL-encoded `application/x-www-form-urlencoded`
+   * string (from `buildSparqlBody`); it is wrapped in single quotes for
+   * the shell, so any literal single quote inside it (e.g. from a SPARQL
+   * string literal like `FILTER(?name = 'John')`) is percent-encoded to
+   * %27 first — otherwise it would prematurely close the shell's quoted
+   * argument and corrupt or break the command.
+   *
+   * @param {string} endpoint - The SPARQL endpoint URL.
+   * @param {string} body - The url-encoded POST body (from buildSparqlBody).
+   * @returns {string} - The full curl command, ready to paste into a terminal.
+   */
+  static _buildCurlCommand(endpoint, body) {
+    const safeBody = body.replace(/'/g, '%27');
+    return `curl -X POST '${endpoint}' \\\n  -H 'Content-Type: application/x-www-form-urlencoded' \\\n  -H 'Accept: application/sparql-results+json' \\\n  -d '${safeBody}'`;
+  }
+
+  /**
    * Display text results.
    * @param {string} content - The text content.
    * @param {string} type - The content type (e.g., 'xml', 'csv', 'text').
@@ -234,28 +258,54 @@ export class QueryResults {
   }
 
   /**
-   * Handle copy URL button click event.
-   * Generates a URL for the current query and copies it to the
-   * clipboard. Uses the shared `copyToClipboard` helper so insecure
-   * contexts (non-HTTPS, older browsers) get the execCommand
-   * fallback instead of a synchronous throw, and a real failure
-   * surfaces via the shared toast instead of a silent
-   * console.error.
+   * Handle share dropdown item click.
+   * Copies the appropriate content to the clipboard based on the
+   * selected share type.
+   * @param {string} type - The share type: 'query-link', 'sparql-query', or 'curl-command'.
    */
-  async onCopyUrl() {
-    const url = this.generateUrl();
-    const copied = await copyToClipboard(url);
+  async onShare(type) {
+    const query = this.queryEditor.getQuery();
+    if (!query || !query.trim()) {
+      showToast('Nothing to copy', 'Write a query first, then try again.', { variant: 'warning' });
+      return;
+    }
+
+    let textToCopy;
+    let toastTitle;
+    let toastBody;
+
+    switch (type) {
+      case 'query-link': {
+        textToCopy = this.generateUrl();
+        toastTitle = 'Query link copied';
+        toastBody = 'Open this link in a browser or any HTTP client to re-run the query and get JSON results.';
+        break;
+      }
+      case 'sparql-query': {
+        textToCopy = query;
+        toastTitle = 'SPARQL query copied';
+        toastBody = 'Paste this into any SPARQL editor to run the same query.';
+        break;
+      }
+      case 'curl-command': {
+        const minifiedQuery = this.queryEditor.minifySparqlQuery(query);
+        const body = buildSparqlBody(minifiedQuery);
+        textToCopy = QueryResults._buildCurlCommand(this.originalSparqlEndpoint, body);
+        toastTitle = 'cURL command copied';
+        toastBody = 'Paste into a terminal to execute the query via command line.';
+        break;
+      }
+      default:
+        return;
+    }
+
+    const copied = await copyToClipboard(textToCopy);
     if (copied) {
-      // SELECT-lane specific success copy: the URL is a JSON
-      // endpoint, consumable by Excel / Power BI / any HTTP client.
-      showToast(
-        'Query URL copied',
-        'You can use it in any app that can load JSON data from the web like Excel, Power BI, etc.',
-      );
+      showToast(toastTitle, toastBody);
     } else {
       showToast(
         'Copy failed',
-        'Could not copy the URL to the clipboard. Please copy it manually from the address bar after clicking Run Query.',
+        'Could not copy to the clipboard. Please try again.',
         { variant: 'danger' },
       );
     }

--- a/src/js/sparqlRequest.js
+++ b/src/js/sparqlRequest.js
@@ -16,8 +16,8 @@
 // Three sites build the same parameter block for the Virtuoso endpoint:
 // QueryEditor.onSubmit (POST body), QueryResults.downloadAs (POST body
 // with a caller-supplied format), and QueryResults.generateUrl (GET URL
-// for Copy endpoint URL). Consolidating them here keeps them honest so
-// "Copy endpoint URL" reproduces exactly what "Run Query" just ran.
+// for Copy Query). Consolidating them here keeps them honest so the
+// query link reproduces exactly what "Run Query" just ran.
 //
 // The options they carry used to come from the Customize tab's Options
 // panel; that UI was removed (issue #32), so readSparqlOptions now returns
@@ -65,9 +65,9 @@ export function buildSparqlBody(query, format = DEFAULT_FORMAT) {
 
 /**
  * Build a GET URL that, when fetched, returns the same result as
- * running the query from the editor. Used by the "Copy endpoint
- * URL" button so the user can paste the URL into Excel / Power BI /
- * any HTTP client.
+ * running the query from the editor. Used by the "Copy Query" →
+ * "Query link" option so the user can paste the URL into Excel /
+ * Power BI / any HTTP client.
  *
  * Applies the same `default-graph-uri` / `timeout` omission rules as
  * `buildSparqlBody` — the copied URL is an exact reproduction of

--- a/src/js/tours/reuseSelectTour.js
+++ b/src/js/tours/reuseSelectTour.js
@@ -47,11 +47,10 @@ export function startReuseSelectTour() {
   steps.push(
     {
       element: '#copy-url-button',
-      title: 'Copy endpoint URL',
+      title: 'Copy Query',
       content:
-        'Copies a URL that returns exactly these results as JSON. Paste it into Excel, ' +
-        'Power BI or any other application that can load JSON from a URL, and you will always ' +
-        'see the latest data without having to re-run the query by hand.',
+        'Copy the query as a link, raw SPARQL text, or a cURL command. The query link returns ' +
+        'these results as JSON — paste it into Excel, Power BI or any HTTP client for live data.',
       placement: 'bottom',
     },
     {

--- a/test/queryResults.test.js
+++ b/test/queryResults.test.js
@@ -127,3 +127,45 @@ test('_renderCell does not make a javascript: URI clickable', () => {
   // protocol so they never match — rendered as plain text.
   assert.equal(node.nodeType, 3);
 });
+
+// ── _buildCurlCommand ──────────────────────────────────────────────
+//
+// The generated command is pasted directly into a shell. A SPARQL query
+// containing a literal single quote (e.g. FILTER(?name = 'John')) survives
+// encodeURIComponent unescaped, since encodeURIComponent does not encode
+// `'`. Left as-is inside the curl command's single-quoted -d argument, it
+// would prematurely close the shell string and corrupt or break the
+// command — these tests pin the %27 escaping that prevents that.
+
+test('_buildCurlCommand includes the endpoint, method, and headers', () => {
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', 'query=x');
+  assert.match(cmd, /^curl -X POST 'https:\/\/example\.com\/sparql'/);
+  assert.match(cmd, /-H 'Content-Type: application\/x-www-form-urlencoded'/);
+  assert.match(cmd, /-H 'Accept: application\/sparql-results\+json'/);
+  assert.match(cmd, /-d 'query=x'/);
+});
+
+test('_buildCurlCommand escapes a literal single quote in the body to %27', () => {
+  // encodeURIComponent leaves ' unescaped, so a SPARQL string literal like
+  // FILTER(?name = 'John') would flow through as a bare quote here.
+  const bodyWithQuote = "query=FILTER(?name%20=%20'John')";
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', bodyWithQuote);
+  assert.doesNotMatch(cmd, /'John'/, 'a literal quote must not survive into the shell argument');
+  assert.match(cmd, /%27John%27/);
+});
+
+test('_buildCurlCommand leaves a body with no single quotes unchanged', () => {
+  const body = 'query=SELECT%20%2A%20WHERE%20%7B%20%3Fs%20%3Fp%20%3Fo%20%7D&format=application%2Fsparql-results%2Bjson';
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', body);
+  assert.match(cmd, new RegExp(`-d '${body}'`));
+});
+
+test('_buildCurlCommand produces a single-quoted -d argument with no unescaped quote inside it', () => {
+  const bodyWithQuote = "query=a'b'c";
+  const cmd = QueryResults._buildCurlCommand('https://example.com/sparql', bodyWithQuote);
+  // Extract the -d argument's quoted content and confirm it contains no
+  // raw single quote (i.e. the shell would see exactly one quoted string).
+  const match = cmd.match(/-d '([^\n]*)'$/);
+  assert.ok(match, 'the -d argument should be present and single-quoted');
+  assert.doesNotMatch(match[1], /'/, 'the body inside the quotes must not contain a raw single quote');
+});

--- a/test/sparqlRequest.test.js
+++ b/test/sparqlRequest.test.js
@@ -87,7 +87,7 @@ test('buildSparqlUrl prefixes the endpoint with a ? separator', () => {
 });
 
 test('buildSparqlUrl produces the same parameter block as buildSparqlBody', () => {
-  // "Copy endpoint URL" must exactly reproduce what Run Query just ran.
+  // "Copy Query" link must exactly reproduce what Run Query just ran.
   const body = buildSparqlBody(QUERY);
   const url = buildSparqlUrl('https://example.com/sparql', QUERY);
   assert.equal(url, `https://example.com/sparql?${body}`);


### PR DESCRIPTION
Resolves #103

The single "Copy endpoint URL" button on the SELECT results toolbar is replaced with a **Copy Query** dropdown offering three options:

- **Query link** — the full GET URL (endpoint + encoded SPARQL) for use in Excel, Power BI, or any HTTP client
- **SPARQL query** — the raw query text from the editor, for pasting into other SPARQL tools
- **cURL command** — a ready-to-paste `curl -X POST` command for terminal use

Single quotes in the SPARQL body are percent-encoded (`%27`) in the cURL output to prevent shell issues when queries contain string literals (e.g. `FILTER(?name = 'John')`).

Also updates the guided tour step, Help tab text, the What's new release notes, and the 504 timeout recovery link to use the new `onShare('query-link')` method.

### Testing
- All 321 automated tests pass (317 existing + 4 new covering the cURL single-quote escaping)
- Manually tested all three Copy Query options in the browser, verified query link/cURL body match and both correctly reproduce what Run Query executes
