### PR TITLE
chore: drop version number from What's new headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -717,7 +717,7 @@
                                 <h3 class="accordion-header" id="release-2-4-0-header">
                                     <button class="accordion-button" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-4-0" aria-expanded="true" aria-controls="release-2-4-0">
-                                        Version 2.4.0 — August 2026
+                                        August 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-4-0" class="accordion-collapse collapse show"
@@ -737,7 +737,7 @@
                                 <h3 class="accordion-header" id="release-2-3-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-3-0" aria-expanded="false" aria-controls="release-2-3-0">
-                                        Version 2.3.0 — July 2026
+                                        July 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-3-0" class="accordion-collapse collapse"
@@ -761,7 +761,7 @@
                                 <h3 class="accordion-header" id="release-2-2-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-2-0" aria-expanded="false" aria-controls="release-2-2-0">
-                                        Version 2.2.0 — May 2026
+                                        May 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-2-0" class="accordion-collapse collapse"
@@ -779,7 +779,7 @@
                                 <h3 class="accordion-header" id="release-2-1-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-1-0" aria-expanded="false" aria-controls="release-2-1-0">
-                                        Version 2.1.0 — April 2026
+                                        April 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-1-0" class="accordion-collapse collapse"
@@ -798,7 +798,7 @@
                                 <h3 class="accordion-header" id="release-2-0-0-header">
                                     <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse"
                                             data-bs-target="#release-2-0-0" aria-expanded="false" aria-controls="release-2-0-0">
-                                        Version 2.0.0 — March 2026
+                                        March 2026
                                     </button>
                                 </h3>
                                 <div id="release-2-0-0" class="accordion-collapse collapse"


### PR DESCRIPTION
Removes the version number from each "What's new" accordion header in the Help tab, keeping only the month/year (e.g. "August 2026" instead of "Version 2.4.0 — August 2026").

Per team decision: the release version number isn't needed for end users here — the month is sufficient context.

### Testing
- All 317 tests pass
- Manually verified in the browser that all 5 accordion headers (2.0.0 through 2.4.0) now show only month/year
